### PR TITLE
Add client features to send transaction

### DIFF
--- a/include/solana_sdk.hpp
+++ b/include/solana_sdk.hpp
@@ -2,6 +2,7 @@
 #define GDEXAMPLE_H
 
 #include <godot_cpp/classes/node.hpp>
+#include <hash.hpp>
 
 namespace godot {
 
@@ -17,6 +18,8 @@ public:
     SolanaSDK();
     static PackedByteArray bs58_decode(String str);
     static String bs58_encode(PackedByteArray input);
+    static String get_latest_blockhash();
+    static Variant send_transaction(const String& transaction);
     ~SolanaSDK();
 };
 }

--- a/include/transaction.hpp
+++ b/include/transaction.hpp
@@ -48,6 +48,7 @@ public:
 
     PackedByteArray serialize();
     Error sign(const Variant &latest_blockhash);
+    Variant sign_and_send();
     Error partially_sign(const Variant& latest_blockhash);
 
     void create_signed_with_payer(Array instructions, Variant payer, Array signers, Variant latest_blockhash);

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -8,6 +8,46 @@
 
 using namespace godot;
 
+
+const char mapping[] = {
+	'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+	'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+	'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/', '=',
+};
+
+String encode64(PackedByteArray bytes);
+	
+/*
+static func decode(str: String) -> PackedByteArray:
+	var ret := PackedByteArray()
+	var cutoff: int = 0
+	
+	# Buffer size with padding
+	ret.resize(str.length() * 6 / 8)
+	
+	for i in range(str.length()):
+		var val := int(mapping.find(str[i]))
+		
+		# If we find padding find how much we need to cut off
+		if str[i] == "=":
+			if i == str.to_utf8_buffer().size() - 1:
+				cutoff = 1
+			else:
+				cutoff = 2
+			break
+		
+		# Arrange bits in 8 bit chunks from 6 bit
+		var index: int = ceil(float(i) * 6.0 / 8.0)
+		var splash: int = val >> ((3 - (i % 4)) * 2)
+		if splash != 0:
+			ret[index - 1] += splash
+		if index >= ret.size():
+			break
+			
+		ret[index] += val << (2 + (i % 4) * 2)
+
+	return ret.slice(0, ret.size() - cutoff)*/
+
 template <typename T>
 void* variant_to_type(Variant var){
 	if(var.get_type() != Variant::OBJECT){

--- a/src/account_meta.cpp
+++ b/src/account_meta.cpp
@@ -5,6 +5,8 @@
 
 namespace godot{
 
+using internal::gde_interface;
+
 void AccountMeta::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_is_signer"), &AccountMeta::get_is_signer);
     ClassDB::bind_method(D_METHOD("set_is_signer", "p_value"), &AccountMeta::set_is_signer);
@@ -31,16 +33,20 @@ void AccountMeta::_update_pointer(){
     }
     else if(object_cast->is_class("Keypair")){
         // Make sure we have a pubkey in the end.
-        Keypair *keypair = Object::cast_to<Keypair>(object_cast);
+        Keypair *keypair = Object::cast_to<Keypair>(key);
         temp_key.set_type("CUSTOM");
         temp_key.set_value(keypair->get_public_value());
-        key_ref = &temp_key;
+        key_ref = temp_key.to_ptr();
+        std::cout << "alalalala" << std::endl;
+        //std::cout << ((Pubkey*)key_ref)->get_value().to_utf8_buffer().ptr() << std::endl;
     }
     else{
+        gde_interface->print_warning("Account Meta does not have a valid key", "_update_pointer", "account_meta.cpp", 44, false);
         return;
     }
 
     if (key_ref == nullptr){
+        gde_interface->print_warning("Account Meta does not have a valid key", "_update_pointer", "account_meta.cpp", 50, false);
         return;
     }
 
@@ -48,7 +54,7 @@ void AccountMeta::_update_pointer(){
 }
 
 void AccountMeta::_free_pointer(){
-    free_account(data_pointer);
+    free_account_meta(data_pointer);
 }
 
 void AccountMeta::set_pubkey(const Variant &p_value) {

--- a/src/keypair.cpp
+++ b/src/keypair.cpp
@@ -119,7 +119,7 @@ void Keypair::set_public_value(const String& p_value){
     if(decoded_value.is_empty() && public_value.length() != 0){
         internal::gde_interface->print_warning("Value contains non-base58 characters", "_set", "keypair.cpp", 119, false);
     }
-    else if (decoded_value.size() != 32){
+    else if (decoded_value.size() != KEY_LENGTH){
         internal::gde_interface->print_warning("Public key must be 32 bytes", "_set", "keypair.cpp", 122, false);
     }
 }
@@ -136,7 +136,7 @@ String Keypair::get_public_value(){
         PackedByteArray keypair_array;
         keypair_array.resize(KEY_LENGTH);
         for(int i = 0; i < KEY_LENGTH; i++){
-            keypair_array[KEY_LENGTH + i] = keypair_bytes[KEY_LENGTH + i];
+            keypair_array[i] = keypair_bytes[KEY_LENGTH + i];
         }
         return SolanaSDK::bs58_encode(keypair_array);
     }
@@ -161,7 +161,7 @@ void Keypair::set_public_bytes(const PackedByteArray& p_value){
     }
 
     // Print warning if key length is bad.
-    if (public_bytes.size() != 32){
+    if (public_bytes.size() != KEY_LENGTH){
         internal::gde_interface->print_warning("Public key must be 32 bytes", "_set", "pubkey.cpp", 147, false);
     }
 }
@@ -177,7 +177,8 @@ PackedByteArray Keypair::get_public_bytes(){
         PackedByteArray keypair_array;
         keypair_array.resize(KEY_LENGTH);
         for(int i = 0; i < KEY_LENGTH; i++){
-            keypair_array[KEY_LENGTH + i] = keypair_bytes[KEY_LENGTH + i];
+            std::cout << (int)keypair_bytes[KEY_LENGTH + i] << std::endl;
+            keypair_array[i] = keypair_bytes[KEY_LENGTH + i];
         }
         return keypair_array;
     }
@@ -215,6 +216,7 @@ String Keypair::get_private_value(){
         PackedByteArray keypair_array;
         keypair_array.resize(KEY_LENGTH);
         for(int i = 0; i < KEY_LENGTH; i++){
+            std::cout << (int)keypair_bytes[KEY_LENGTH + i] << std::endl;
             keypair_array[i] = keypair_bytes[i];
         }
         return SolanaSDK::bs58_encode(keypair_array);

--- a/src/solana_sdk.cpp
+++ b/src/solana_sdk.cpp
@@ -3,13 +3,20 @@
 #include "../wrapper/wrapper.h"
 
 #include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/classes/http_request.hpp>
+#include <godot_cpp/classes/tls_options.hpp>
+#include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/classes/json.hpp>
 #include <utils.hpp>
 
 using namespace godot;
 
+using internal::gde_interface;
+
 void SolanaSDK::_bind_methods() {
     ClassDB::bind_static_method("SolanaSDK", D_METHOD("bs58_encode", "input"), &SolanaSDK::bs58_encode);
     ClassDB::bind_static_method("SolanaSDK", D_METHOD("bs58_decode", "input"), &SolanaSDK::bs58_decode);
+    ClassDB::bind_static_method("SolanaSDK", D_METHOD("get_latest_blockhash"), &SolanaSDK::get_latest_blockhash);
 }
 
 SolanaSDK::SolanaSDK() {
@@ -36,6 +43,144 @@ String SolanaSDK::bs58_encode(PackedByteArray input){
 		result[i] = buffer[i];
 	}
 	return result.get_string_from_utf8();
+}
+
+String SolanaSDK::get_latest_blockhash(){
+	const int32_t POLL_DELAY_MSEC = 10;
+	const godot::String RPC_URL = "https://api.devnet.solana.com";
+	const godot::String REQUEST_DATA = "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"getLatestBlockhash\",\"params\":[{\"commitment\":\"finalized\"}]}";
+
+	// Set headers
+	PackedStringArray http_headers;
+	http_headers.append("Content-Type: application/json");
+	http_headers.append("Accept-Encoding: json");
+	
+	// Connect to RPC API URL.
+	HTTPClient handler;
+	Error err = handler.connect_to_host(RPC_URL, 443, TLSOptions::client_unsafe());
+
+	// Wait until a connection is established.
+	godot::HTTPClient::Status status = handler.get_status();
+	while(status == HTTPClient::STATUS_CONNECTING || status == HTTPClient::STATUS_RESOLVING){
+		handler.poll();
+		OS::get_singleton()->delay_msec(POLL_DELAY_MSEC);
+		status = handler.get_status();
+	}
+
+	// Make a POST request
+	err = handler.request(godot::HTTPClient::METHOD_POST, "/", http_headers, REQUEST_DATA);
+
+	if(err != Error::OK){
+		gde_interface->print_error("Error sending request.", "get_latest_blockhash", "solana_sdk.cpp", __LINE__, false);
+		return "";
+	}
+
+	// Poll until we have a response.
+	status = handler.get_status();
+	while(status == HTTPClient::STATUS_REQUESTING){
+		handler.poll();
+		OS::get_singleton()->delay_msec(POLL_DELAY_MSEC);
+		status = handler.get_status();
+	}
+
+	// Collect the response body.
+	PackedByteArray response_data;
+	while(status == HTTPClient::STATUS_BODY){
+		response_data.append_array(handler.read_response_body_chunk());
+		handler.poll();
+		status = handler.get_status();
+	}
+
+	handler.close();
+
+	// Parse out the blockhash.
+	JSON json;
+	err = json.parse(response_data.get_string_from_utf8());
+
+	if(err != Error::OK){
+		gde_interface->print_error("Error getting response data.", "get_latest_blockhash", "solana_sdk.cpp", __LINE__, false);
+		return "";
+	}
+
+	Dictionary data = json.get_data();
+	if(!data.has("result")){
+		gde_interface->print_error("Unexpected response.", "get_latest_blockhash", "solana_sdk.cpp", __LINE__, false);
+		return "";
+	}
+	data = data["result"];
+	if(!data.has("value")){
+		gde_interface->print_error("Unexpected response.", "get_latest_blockhash", "solana_sdk.cpp", __LINE__, false);
+		return "";
+	}
+	data = data["value"];
+	if(!data.has("blockhash")){
+		gde_interface->print_error("Unexpected response.", "get_latest_blockhash", "solana_sdk.cpp", __LINE__, false);
+		return "";
+	}
+
+	return data["blockhash"];
+}
+
+Variant SolanaSDK::send_transaction(const String& transaction){
+	const int32_t POLL_DELAY_MSEC = 10;
+	const godot::String RPC_URL = "https://api.devnet.solana.com";
+	const godot::String REQUEST_DATA = "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"sendTransaction\",\"params\":[\"" + transaction + "\",{\"encoding\":\"base64\"}]}";
+
+	std::cout << REQUEST_DATA.to_utf8_buffer().ptr() << std::endl;
+
+	// Set headers
+	PackedStringArray http_headers;
+	http_headers.append("Content-Type: application/json");
+	http_headers.append("Accept-Encoding: json");
+	
+	// Connect to RPC API URL.
+	HTTPClient handler;
+	Error err = handler.connect_to_host(RPC_URL, 443, TLSOptions::client_unsafe());
+
+	// Wait until a connection is established.
+	godot::HTTPClient::Status status = handler.get_status();
+	while(status == HTTPClient::STATUS_CONNECTING || status == HTTPClient::STATUS_RESOLVING){
+		handler.poll();
+		OS::get_singleton()->delay_msec(POLL_DELAY_MSEC);
+		status = handler.get_status();
+	}
+
+	// Make a POST request
+	err = handler.request(godot::HTTPClient::METHOD_POST, "/", http_headers, REQUEST_DATA);
+
+	if(err != Error::OK){
+		gde_interface->print_error("Error sending request.", "send_transaction", "solana_sdk.cpp", __LINE__, false);
+		return "";
+	}
+
+	// Poll until we have a response.
+	status = handler.get_status();
+	while(status == HTTPClient::STATUS_REQUESTING){
+		handler.poll();
+		OS::get_singleton()->delay_msec(POLL_DELAY_MSEC);
+		status = handler.get_status();
+	}
+
+	// Collect the response body.
+	PackedByteArray response_data;
+	while(status == HTTPClient::STATUS_BODY){
+		response_data.append_array(handler.read_response_body_chunk());
+		handler.poll();
+		status = handler.get_status();
+	}
+
+	handler.close();
+
+	// Parse out the blockhash.
+	JSON json;
+	err = json.parse(response_data.get_string_from_utf8());
+
+	if(err != Error::OK){
+		gde_interface->print_error("Error getting response data.", "send_transaction", "solana_sdk.cpp", __LINE__, false);
+		return "";
+	}
+
+	return json.get_data();
 }
 
 SolanaSDK::~SolanaSDK() {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,26 @@
+#include "utils.hpp"
+
+String encode64(PackedByteArray bytes){
+	String r = ""; 
+	String p = ""; 
+
+	int64_t c = bytes.size() % 3;
+
+	if(c > 0){
+		for(int i = c; i < 3; i++){
+			p += '='; 
+			bytes.append(0);
+		}
+	}
+
+	for(int i = 0; i < bytes.size(); i += 3){
+		int n = (bytes[i] << 16) + (bytes[i + 1] << 8) + bytes[i + 2];
+
+		r += mapping[(n >> 18) & 63];
+		r += mapping[(n >> 12) & 63];
+		r += mapping[(n >> 6) & 63];
+		r += mapping[n & 63];
+	}
+
+	return r.substr(0, r.length() - p.length()) + p;
+}


### PR DESCRIPTION
Sending the transaction requires another solana-client plugin. This is not necessary since there is a HTTPClient class. This commit adds implementations for signing and sending transaction without the client plugin.