### PR TITLE
Fix update blockhash function

### DIFF
--- a/include/message.hpp
+++ b/include/message.hpp
@@ -26,7 +26,7 @@ private:
     void compile_instruction(Variant instruction);
     void recalculate_headers();
 
-    int locate_account_meta(const TypedArray<Resource>& arr, const AccountMeta &input);
+    int locate_account_meta(const TypedArray<Resource>& arr, const AccountMeta &input, bool is_payer = false);
 
 protected:
     static void _bind_methods();

--- a/include/transaction.hpp
+++ b/include/transaction.hpp
@@ -35,6 +35,8 @@ protected:
 public:
     Transaction();
 
+    void _ready() override;
+
     void set_instructions(const Array& p_value);
     Array get_instructions();
 

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -9,6 +9,7 @@
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/thread.hpp>
 #include <godot_cpp/classes/http_request.hpp>
+#include <solana_client.hpp>
 #include <solana_sdk.hpp>
 #include <phantom.hpp>
 #include <message.hpp>
@@ -154,6 +155,10 @@ void Transaction::set_payer(const Variant& p_value){
     }
 }
 
+void Transaction::_ready(){
+    create_message();
+}
+
 Variant Transaction::get_payer(){
     return payer;
 }
@@ -168,9 +173,12 @@ bool Transaction::get_use_phantom_payer(){
 }
 
 void Transaction::update_latest_blockhash(const String &custom_hash){
-    if(!custom_hash.is_empty()){
-        const String latest_blockhash = SolanaSDK::get_latest_blockhash();
-        Object::cast_to<Message>(message)->set_latest_blockhash(latest_blockhash);
+    if(custom_hash.is_empty()){
+        const Dictionary latest_blockhash = SolanaClient::get_latest_blockhash();
+        const Dictionary blockhash_result = latest_blockhash["result"];
+        const Dictionary blockhash_value = blockhash_result["value"];
+        String hash_string = blockhash_value["blockhash"];
+        Object::cast_to<Message>(message)->set_latest_blockhash(hash_string);
     }
     else{
         Object::cast_to<Message>(message)->set_latest_blockhash(custom_hash);


### PR DESCRIPTION
The transaction method update_blockhash is broken. This commit introduces a temporary fix that uses an extra parameter to a account meta find algorithm. There are also some issues fixed with inverted logic.