### PR TITLE
Add return value to transaction send

### DIFF
--- a/include/transaction.hpp
+++ b/include/transaction.hpp
@@ -24,7 +24,6 @@ private:
 
     void _get_property_list(List<PropertyInfo> *p_list) const;
 
-    void _transaction_response(int result, int response_code, PackedStringArray headers, PackedByteArray body);
     void _payer_signed(PackedByteArray signature);
 
     void create_message();
@@ -57,8 +56,8 @@ public:
     PackedByteArray serialize();
     PackedByteArray serialize_message();
     PackedByteArray serialize_signers();
-    Error sign(const Variant &latest_blockhash);
-    Error send();
+    Error sign();
+    Dictionary send();
     Variant sign_and_send();
     Error partially_sign(const Variant& latest_blockhash);
 


### PR DESCRIPTION
There is no way to get any result from sent transactions. This commit adds a return value for the send method. The result from the SolanaClient is passed as return.