### PR TITLE
Add mandatory compute budget instructions to transactions.

### DIFF
--- a/include/message.hpp
+++ b/include/message.hpp
@@ -17,7 +17,7 @@ private:
     uint8_t num_readonly_signed_accounts = 0;
     uint8_t num_readonly_unsigned_accounts = 0;
     TypedArray<Resource> account_keys;
-    Variant latest_blockhash;
+    String latest_blockhash;
     TypedArray<CompiledInstruction> compiled_instructions;
     TypedArray<Resource> signers;
 

--- a/include/transaction.hpp
+++ b/include/transaction.hpp
@@ -20,6 +20,8 @@ private:
     Variant payer;
     Array signers;
     TypedArray<PackedByteArray> signatures;
+
+    bool has_cumpute_budget_instructions = false;
     bool use_phantom_payer;
 
     void _get_property_list(List<PropertyInfo> *p_list) const;
@@ -27,6 +29,7 @@ private:
     void _payer_signed(PackedByteArray signature);
 
     void create_message();
+    void prepend_compute_budget_instructions();
 
 protected:
     static void _bind_methods();

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -114,7 +114,7 @@ Message::Message(TypedArray<Instruction> instructions, Variant &payer){
     AccountMeta *payer_meta = memnew(AccountMeta(payer_key, true, true));
     merged_metas.append(payer_meta);
 
-    latest_blockhash = memnew(Hash);
+    latest_blockhash = "";
 
     for(unsigned int i = 0; i < instructions.size(); i++){
         Instruction *element = Object::cast_to<Instruction>(instructions[i]);
@@ -180,11 +180,7 @@ Message::Message(TypedArray<Instruction> instructions, Variant &payer){
 }
 
 void Message::set_latest_blockhash(const String& blockhash){
-    if(latest_blockhash.get_type() == Variant::NIL){
-        latest_blockhash = memnew(Hash);
-    }
-
-    Object::cast_to<Hash>(latest_blockhash)->set_value(blockhash);
+    latest_blockhash = blockhash;
 }
 
 PackedByteArray Message::serialize(){
@@ -242,21 +238,13 @@ int Message::locate_account_meta(const TypedArray<Resource>& arr, const AccountM
 }
 
 PackedByteArray Message::serialize_blockhash(){
-    if(latest_blockhash.get_type() != Variant::OBJECT){
+    if(latest_blockhash.is_empty()){
         PackedByteArray result;
         result.resize(32);
         return result;
     }
 
-    Hash *latest_blockhash_pubkey = Object::cast_to<Hash>(latest_blockhash);
-    PackedByteArray result = latest_blockhash_pubkey->get_bytes();
-
-    // If blockhash is not set yet, return 32 zeros.
-    if(result.size() != 32){
-        result.resize(32);
-    }
-
-    return result;
+    return SolanaSDK::bs58_decode(latest_blockhash);
 }
 
 int Message::get_amount_signers(){

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -37,6 +37,8 @@ void initialize_solana_sdk_module(ModuleInitializationLevel p_level) {
     ClassDB::register_class<Transaction>();
     ClassDB::register_class<Keypair>();
     ClassDB::register_class<PhantomController>();
+
+    SolanaClient::set_commitment("finalized");
 }
 
 void uninitialize_solana_sdk_module(ModuleInitializationLevel p_level) {

--- a/src/solana_client.cpp
+++ b/src/solana_client.cpp
@@ -93,6 +93,10 @@ void SolanaClient::append_limit(Array& options){
 }
 
 void SolanaClient::add_to_param_dict(Array &options, const String& key, const Variant& value){
+    if(options.is_empty()){
+        options.append(make_rpc_param(key, value));
+        return;
+    }
     if(options.back().get_type() == Variant::DICTIONARY){
         Dictionary dict = options.back();
         dict[key] = value;
@@ -692,10 +696,27 @@ Dictionary SolanaClient::simulate_transaction(const String& encoded_transaction,
 }
 
 void SolanaClient::_bind_methods(){
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("set_url", "url"), &SolanaClient::set_url);
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("set_encoding", "encoding"), &SolanaClient::set_encoding);
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("set_commitment", "commitment"), &SolanaClient::set_commitment);
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("set_transaction_detail", "transaction_detail"), &SolanaClient::set_transaction_detail);
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("enable_min_context_slot", "slot"), &SolanaClient::enable_min_context_slot);
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("disable_min_context_slot"), &SolanaClient::disable_min_context_slot);
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("enable_account_filter", "offset", "length"), &SolanaClient::enable_account_filter);
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("disable_account_filter"), &SolanaClient::disable_account_filter);
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("enable_max_transaction_version", "version"), &SolanaClient::enable_max_transaction_version);
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("disable_max_transaction_version"), &SolanaClient::disable_max_transaction_version);
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("enable_rewards"), &SolanaClient::enable_rewards);
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("disable_rewards"), &SolanaClient::disable_rewards);
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("enable_identity", "identity"), &SolanaClient::enable_identity);
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("disable_identity"), &SolanaClient::disable_identity);
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("enable_slot_range", "first", "last"), &SolanaClient::enable_slot_range);
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("disable_slot_range"), &SolanaClient::disable_slot_range);
+
+
     ClassDB::bind_static_method("SolanaClient", D_METHOD("get_latest_blockhash"), &SolanaClient::get_latest_blockhash);
     ClassDB::bind_static_method("SolanaClient", D_METHOD("get_balance", "account"), &SolanaClient::get_balance);
     ClassDB::bind_static_method("SolanaClient", D_METHOD("get_account_info", "account"), &SolanaClient::get_account_info);
-    ClassDB::bind_static_method("SolanaClient", D_METHOD("set_url", "url"), &SolanaClient::set_url);
     ClassDB::bind_static_method("SolanaClient", D_METHOD("get_block", "slot"), &SolanaClient::get_block);
     ClassDB::bind_static_method("SolanaClient", D_METHOD("get_block_height"), &SolanaClient::get_block_height);
     ClassDB::bind_static_method("SolanaClient", D_METHOD("get_block_commitment", "slot"), &SolanaClient::get_block_commitment);
@@ -749,6 +770,7 @@ void SolanaClient::_bind_methods(){
 
 SolanaClient::SolanaClient(){
     transaction_detail = "full";
+    commitment = "finalized";
 }
 
 void SolanaClient::set_url(const String& url){

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -60,6 +60,10 @@ void Transaction::create_message(){
         return;
     }
 
+    if(!has_cumpute_budget_instructions){
+        prepend_compute_budget_instructions();
+    }
+
     message = memnew(Message(instructions, payer));
     const int amount_of_signers = Object::cast_to<Message>(message)->get_amount_signers();
     signatures.resize(amount_of_signers);
@@ -68,6 +72,34 @@ void Transaction::create_message(){
         temp.resize(64);
         signatures[i] = temp;
     }
+}
+
+void Transaction::prepend_compute_budget_instructions(){
+    // TODO(Virax): Replace with system instruction class.
+
+    String compute_budget_id = "ComputeBudget111111111111111111111111111111";
+    Instruction* inst = memnew(Instruction);
+    PackedByteArray data;
+    data.resize(9);
+    data[0] = 3;
+    data[1] = 64;
+    data[2] = 31;
+    inst->set_program_id(memnew(Pubkey(compute_budget_id)));
+    inst->set_data(data);
+    instructions.insert(0, inst);
+
+    inst = memnew(Instruction);
+    data.clear();
+    data.resize(5);
+    data[0] = 2;
+    data[1] = 64;
+    data[2] = 13;
+    data[3] = 3;
+    inst->set_program_id(memnew(Pubkey(compute_budget_id)));
+    inst->set_data(data);
+    instructions.insert(1, inst);
+
+    has_cumpute_budget_instructions = true;
 }
 
 bool Transaction::_set(const StringName &p_name, const Variant &p_value){


### PR DESCRIPTION
The Compute budget instructions are prepended to transaction instruction array when phantom is signing. This commit adds the same instructions to get a valid signature from phantom. The instructions are to be replaced by system instruction with input parameters.