### PR TITLE
Fix ComputeBudget bug

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -17,7 +17,7 @@ def get_build_command(platform, architecture, debug=False):
     if platform == 'ios':
         arguments = 'IOS_SDK_PATH="/root/ioscross/arm64/SDK/iPhoneOS{}.sdk" IOS_TOOLCHAIN_PATH="/root/ioscross/arm64" ios_triple="arm-apple-darwin11-"'.format(IPHONE_SDK_VERSION)
     elif platform == 'macos':
-        arguments = 'macos_sdk_path="/root/osxcross/target/SDK/MacOSX13.0.sdk/" osxcross_sdk="darwin22"'    
+        arguments = 'macos_sdk_path="/root/osxcross/target/SDK/MacOSX14.0.sdk/" osxcross_sdk="darwin23"'    
     elif platform == 'android':
         arguments = ""
     elif platform == 'web':
@@ -116,6 +116,8 @@ env.Append(CPPPATH=["sha256/"])
 env.Append(CPPPATH=["BLAKE3/c/"])
 env.Append(CPPPATH=["ed25519/src/"])
 env.Append(CPPPATH=["phantom/"])
+env.Append(CPPPATH=["instructions/include"])
+env.Append(CPPPATH=["instructions/src"])
 env.Append(CCFLAGS=[
     "-DBLAKE3_NO_SSE41",
     "-DBLAKE3_NO_SSE2",
@@ -125,6 +127,7 @@ env.Append(CCFLAGS=[
 ])
 
 sources = Glob("src/*.cpp")
+
 blak3_sources = Glob("BLAKE3/c/blake3.c")
 blak3_sources.append(Glob("BLAKE3/c/blake3_dispatch.c")[0])
 blak3_sources.append(Glob("BLAKE3/c/blake3_portable.c")[0])
@@ -133,6 +136,7 @@ sha256_sources = Glob("sha256/sha256.cpp")
 ed25519_sources = Glob("ed25519/src/*.c")
 
 phantom_sources = Glob("phantom/*.cpp")
+instruction_sources = Glob("instructions/src/*.cpp")
 
 # Handle the container build
 if env.GetOption('container_build'):
@@ -168,12 +172,12 @@ else:
             ) + LIBRARY_NAME + ".{}.{}".format(
                 env["platform"], env["target"]
             ),
-            source=sources + blak3_sources + sha256_sources + ed25519_sources + phantom_sources #+ cryptopp_sources,
+            source=sources + blak3_sources + sha256_sources + ed25519_sources + phantom_sources + instruction_sources,
         )
     else:
         library = env.SharedLibrary(
             "bin/lib" + LIBRARY_NAME + "{}{}".format(env["suffix"], env["SHLIBSUFFIX"]),
-            source=sources + blak3_sources + sha256_sources + ed25519_sources + phantom_sources #+ cryptopp_sources,
+            source=sources + blak3_sources + sha256_sources + ed25519_sources + phantom_sources + instruction_sources,
         )
 
     Default(library)

--- a/include/account_meta.hpp
+++ b/include/account_meta.hpp
@@ -26,7 +26,7 @@ protected:
 public:
     AccountMeta();
     AccountMeta(const Variant& pid, bool signer, bool writeable);
-    //AccountMeta(const Variant& other);
+    AccountMeta(const Variant& other);
 
     void set_pubkey(const Variant &p_value);
     Variant get_pubkey() const;

--- a/include/instruction.hpp
+++ b/include/instruction.hpp
@@ -15,6 +15,7 @@ MAKE_TYPED_ARRAY(Pubkey, Variant::OBJECT)
 MAKE_TYPED_ARRAY(AccountMeta, Variant::OBJECT)
 MAKE_TYPED_ARRAY(Resource, Variant::OBJECT)
 
+class CompiledInstruction;
 
 class Instruction : public Resource {
     GDCLASS(Instruction, Resource)
@@ -38,6 +39,8 @@ public:
 
     void set_accounts(const TypedArray<AccountMeta>& p_value);
     TypedArray<AccountMeta> get_accounts();
+
+    PackedByteArray serialize();
     
     ~Instruction();
 };

--- a/include/message.hpp
+++ b/include/message.hpp
@@ -4,6 +4,8 @@
 #include <instruction.hpp>
 #include <godot_cpp/classes/node.hpp>
 
+#include "keypair.hpp"
+
 namespace godot{
 
 MAKE_TYPED_ARRAY(CompiledInstruction, Variant::OBJECT)
@@ -16,17 +18,18 @@ private:
     uint8_t num_required_signatures = 0;
     uint8_t num_readonly_signed_accounts = 0;
     uint8_t num_readonly_unsigned_accounts = 0;
-    TypedArray<Resource> account_keys;
+    TypedArray<Pubkey> account_keys;
     String latest_blockhash;
     TypedArray<CompiledInstruction> compiled_instructions;
-    TypedArray<Resource> signers;
+    TypedArray<Keypair> signers;
 
-    TypedArray<Resource> merged_metas;
+    TypedArray<AccountMeta> merged_metas;
 
     void compile_instruction(Variant instruction);
     void recalculate_headers();
+    void merge_account_meta(const AccountMeta& account_meta);
 
-    int locate_account_meta(const TypedArray<Resource>& arr, const AccountMeta &input, bool is_payer = false);
+    int locate_account_meta(const TypedArray<AccountMeta>& arr, const AccountMeta &input);
 
 protected:
     static void _bind_methods();
@@ -38,7 +41,7 @@ public:
     PackedByteArray serialize();
     PackedByteArray serialize_blockhash();
     int get_amount_signers();
-    TypedArray<Resource> &get_signers();
+    TypedArray<Keypair> &get_signers();
     ~Message();
 };
 }

--- a/include/pubkey.hpp
+++ b/include/pubkey.hpp
@@ -42,9 +42,10 @@ protected:
 public:
     Pubkey();
     Pubkey(const String& from);
+    Pubkey(const Variant& from);
 
     void set_value(const String& p_value);
-    String get_value();
+    String get_value() const;
 
     void set_seed(const String& p_value);
     String get_seed();
@@ -53,7 +54,7 @@ public:
     PackedByteArray get_bytes() const;
 
     void set_type(const String p_value);
-    String get_type();
+    String get_type() const;
 
     void set_base(const Variant p_value);
     Variant get_base();

--- a/include/transaction.hpp
+++ b/include/transaction.hpp
@@ -21,6 +21,8 @@ private:
     Array signers;
     TypedArray<PackedByteArray> signatures;
 
+    String latest_blockhash_string = "";
+
     bool has_cumpute_budget_instructions = false;
     bool use_phantom_payer;
 
@@ -29,15 +31,12 @@ private:
     void _payer_signed(PackedByteArray signature);
 
     void create_message();
-    void prepend_compute_budget_instructions();
 
 protected:
     static void _bind_methods();
 
 public:
     Transaction();
-
-    void _ready() override;
 
     void set_instructions(const Array& p_value);
     Array get_instructions();

--- a/instructions/include/compute_budget.hpp
+++ b/instructions/include/compute_budget.hpp
@@ -1,0 +1,28 @@
+#ifndef SOLANA_SDK_COMPUTE_BUDGET_HPP
+#define SOLANA_SDK_COMPUTE_BUDGET_HPP
+
+#include <godot_cpp/classes/node.hpp>
+#include <instruction.hpp>
+
+namespace godot{
+
+class ComputeBudget : public Node{
+    GDCLASS(ComputeBudget, Node)
+private:
+
+    static const int COMPUTE_UNIT_LIMIT_DATA_SIZE = 5;
+    static const int COMPUTE_UNIT_PRICE_DATA_SIZE = 9;
+
+protected:
+    static void _bind_methods();
+
+public:
+    static const std::string ID;
+
+    static Variant set_compute_unit_limit(const uint32_t unit_limit);
+    static Variant set_compute_unit_price(const uint32_t unit_price);
+};
+
+}
+
+#endif

--- a/instructions/src/compute_budget.cpp
+++ b/instructions/src/compute_budget.cpp
@@ -1,0 +1,60 @@
+#include "compute_budget.hpp"
+
+namespace godot{
+
+PackedByteArray encode_u32(uint32_t input){
+    PackedByteArray result;
+    result.resize(4);
+    result[3] = (uint8_t) (input >> 24);
+    result[2] = (uint8_t) (input >> 16);
+    result[1] = (uint8_t) (input >> 8);
+    result[0] = (uint8_t) input;
+    return result;
+}
+
+const std::string ComputeBudget::ID = "ComputeBudget111111111111111111111111111111";
+
+void ComputeBudget::_bind_methods(){
+    ClassDB::bind_static_method("ComputeBudget", D_METHOD("set_compute_unit_limit", "unit_limit"), &ComputeBudget::set_compute_unit_limit);
+    ClassDB::bind_static_method("ComputeBudget", D_METHOD("set_compute_unit_price", "unit_price"), &ComputeBudget::set_compute_unit_price);
+}
+
+Variant ComputeBudget::set_compute_unit_limit(const uint32_t unit_limit){
+    Instruction *result = memnew(Instruction);
+    PackedByteArray data;
+    data.resize(COMPUTE_UNIT_LIMIT_DATA_SIZE);
+    
+    data[0] = 2;
+    const PackedByteArray encoded_int = encode_u32(unit_limit);
+    for(int i = 0; i < 4; i++){
+        data[1 + i] = encoded_int[i];
+    }
+
+    const Variant new_pid = memnew(Pubkey(String(ID.c_str())));
+    result->set_program_id(new_pid);
+    result->set_data(data);
+
+    return result;
+}
+
+Variant ComputeBudget::set_compute_unit_price(const uint32_t unit_price){
+    Instruction *result = memnew(Instruction);
+    PackedByteArray data;
+    data.resize(COMPUTE_UNIT_PRICE_DATA_SIZE);
+    
+    data[0] = 3;
+    // TODO(Virax): Use built in function instead.
+    const PackedByteArray encoded_int = encode_u32(unit_price);
+    for(int i = 0; i < 4; i++){
+        data[1 + i] = encoded_int[i];
+    }
+
+    const Variant new_pid = memnew(Pubkey(String(ID.c_str())));
+    result->set_program_id(new_pid);
+    result->set_data(data);
+
+    return result;
+}
+
+
+}

--- a/src/account_meta.cpp
+++ b/src/account_meta.cpp
@@ -81,9 +81,22 @@ AccountMeta::AccountMeta() : Resource(){
 }
 
 AccountMeta::AccountMeta(const Variant& pid, bool signer, bool writeable){
-    this->set_pubkey(pid);
+    const Pubkey *temp = memnew(Pubkey(pid));
+    this->key = temp;
     this->is_signer = signer;
     this->writeable = writeable;
+}
+
+AccountMeta::AccountMeta(const Variant& other){
+    if(other.has_method("get_pubkey")){
+        const AccountMeta* meta_ptr = Object::cast_to<AccountMeta>(other);
+        this->key = meta_ptr->get_pubkey();
+        this->is_signer = meta_ptr->get_is_signer();
+        this->writeable = meta_ptr->get_writeable();
+    }
+    else{
+        internal::gdextension_interface_print_warning("Assigning AccountMeta with an unexpected object.", "assignment constructor", __FILE__, __LINE__, false);
+    }
 }
 
 void AccountMeta::create_new(const Variant& account_key, bool is_signer, bool writeable){

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -22,9 +22,12 @@ void Instruction::_bind_methods() {
     ClassDB::bind_method(D_METHOD("set_data", "p_value"), &Instruction::set_data);
     ClassDB::bind_method(D_METHOD("get_accounts"), &Instruction::get_accounts);
     ClassDB::bind_method(D_METHOD("set_accounts", "p_value"), &Instruction::set_accounts);
+    ClassDB::bind_method(D_METHOD("serialize"), &Instruction::serialize);
+
     ClassDB::add_property("Instruction", PropertyInfo(Variant::OBJECT, "program_id", PROPERTY_HINT_RESOURCE_TYPE, "Pubkey", PROPERTY_USAGE_DEFAULT), "set_program_id", "get_program_id");
     ClassDB::add_property("Instruction", PropertyInfo(Variant::PACKED_BYTE_ARRAY, "data"), "set_data", "get_data");
-    ClassDB::add_property("Instruction", PropertyInfo(Variant::ARRAY, "accounts", PROPERTY_HINT_ARRAY_TYPE, MAKE_RESOURCE_TYPE_HINT("AccountMeta")), "set_accounts", "get_accounts");}
+    ClassDB::add_property("Instruction", PropertyInfo(Variant::ARRAY, "accounts", PROPERTY_HINT_ARRAY_TYPE, MAKE_RESOURCE_TYPE_HINT("AccountMeta")), "set_accounts", "get_accounts");
+}
 
 Instruction::Instruction() {
 }
@@ -51,6 +54,22 @@ TypedArray<AccountMeta> Instruction::get_accounts(){
     return accounts;
 }
 
+PackedByteArray Instruction::serialize(){
+    PackedByteArray result;
+
+    if(program_id.has_method("get_bytes")){
+        result.append_array(Object::cast_to<Pubkey>(program_id)->get_bytes());
+    }
+    result.append_array(data);
+    for(unsigned int i = 0; i < accounts.size(); i++){
+        const Pubkey key = accounts[i];
+
+        result.append_array(key.get_bytes());
+    }
+
+    return result;
+}
+
 Instruction::~Instruction() {
 }
 
@@ -60,7 +79,6 @@ CompiledInstruction::CompiledInstruction(){
 }
 
 void CompiledInstruction::_bind_methods(){
-
 }
 
 PackedByteArray CompiledInstruction::serialize(){

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -12,6 +12,7 @@
 #include "phantom.hpp"
 #include "message.hpp"
 #include "solana_client.hpp"
+#include "compute_budget.hpp"
 
 #include <gdextension_interface.h>
 #include <godot_cpp/core/defs.hpp>
@@ -37,6 +38,7 @@ void initialize_solana_sdk_module(ModuleInitializationLevel p_level) {
     ClassDB::register_class<Transaction>();
     ClassDB::register_class<Keypair>();
     ClassDB::register_class<PhantomController>();
+    ClassDB::register_class<ComputeBudget>();
 
     SolanaClient::set_commitment("finalized");
 }


### PR DESCRIPTION
The prepended compute budget instructions cause issues. There are some serialization issues and they are prepended once the editor is restarted. This commit fixes this by removing reduntant code and refactoring message creation and instruction compilation.