### PR TITLE
Bind GDScript to program address creation

### DIFF
--- a/include/instruction.hpp
+++ b/include/instruction.hpp
@@ -43,6 +43,7 @@ public:
     void append_meta(const AccountMeta& meta);
 
     PackedByteArray serialize();
+    bool is_serializable();
     
     ~Instruction();
 };

--- a/include/keypair.hpp
+++ b/include/keypair.hpp
@@ -39,6 +39,9 @@ public:
     Keypair();
     Keypair(const PackedByteArray &seed);
     
+    static Variant new_from_seed(const String &seed);
+    static Variant new_from_seed(const PackedByteArray &seed);
+
     void set_public_value(const String& p_value);
     String get_public_value();
 

--- a/include/pubkey.hpp
+++ b/include/pubkey.hpp
@@ -70,7 +70,13 @@ public:
 
     void create_from_string(const String& from);
     void create_from_array(const unsigned char* data);
-    static Variant create_with_seed(Variant basePubkey, String seed, Variant owner_pubkey);
+
+    static Variant new_from_seed(Variant basePubkey, String seed, Variant owner_pubkey);
+    static Variant new_from_string(const String& from);
+    static Variant new_program_address(const PackedStringArray seeds, const Variant &program_id);
+    static Variant new_associated_token_address(const Variant &wallet_address, const Variant &token_mint_address);
+
+
     bool create_program_address(const PackedStringArray seeds, const Variant &program_id);
     bool get_associated_token_address(const Variant &wallet_address, const Variant &token_mint_address);
 

--- a/instructions/src/system_program.cpp
+++ b/instructions/src/system_program.cpp
@@ -60,7 +60,7 @@ Variant SystemProgram::create_account_with_seed(const Variant &from_keypair, con
         data[4 + i] = base_bytes[i];
     }
 
-    Variant created_account_key = Pubkey::create_with_seed(base_keypair, seed, owner);
+    Variant created_account_key = Pubkey::new_from_seed(base_keypair, seed, owner);
 
     const Variant new_pid = memnew(Pubkey(String(ID.c_str())));
     result->set_program_id(new_pid);

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -15,6 +15,18 @@ namespace godot{
 
 using internal::gdextension_interface_print_warning;
 
+bool Instruction::is_serializable(){
+    if(program_id.get_type() != Variant::OBJECT){
+        return false;
+    }
+    for(unsigned int i = 0; i < accounts.size(); i++){
+        if(accounts[i].get_type() != Variant::OBJECT){
+            return false;
+        }
+    }
+    return true;
+}
+
 void Instruction::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_program_id"), &Instruction::get_program_id);
     ClassDB::bind_method(D_METHOD("set_program_id", "p_value"), &Instruction::set_program_id);

--- a/src/keypair.cpp
+++ b/src/keypair.cpp
@@ -7,6 +7,8 @@
 namespace godot{
 
 void Keypair::_bind_methods() {
+    ClassDB::bind_static_method("Keypair", D_METHOD("new_from_seed", "seed"), (Variant(*)(const PackedByteArray&))&Keypair::new_from_seed);
+
     ClassDB::bind_method(D_METHOD("get_public_value"), &Keypair::get_public_value);
     ClassDB::bind_method(D_METHOD("set_public_value", "p_value"), &Keypair::set_public_value);
     ClassDB::bind_method(D_METHOD("get_public_bytes"), &Keypair::get_public_bytes);
@@ -142,6 +144,18 @@ Keypair::Keypair(const PackedByteArray &seed){
 
     private_value = SolanaSDK::bs58_encode(private_bytes);
     public_value = SolanaSDK::bs58_encode(public_bytes);
+}
+
+Variant Keypair::new_from_seed(const String &seed){
+    Keypair *res = memnew(Keypair);
+    res->set_seed(seed.to_ascii_buffer());
+    return res;
+}
+
+Variant Keypair::new_from_seed(const PackedByteArray &seed){
+    Keypair *res = memnew(Keypair);
+    res->set_seed(seed);
+    return res;
 }
 
 void Keypair::set_public_value(const String& p_value){

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -20,7 +20,10 @@ bool Pubkey::are_bytes_curve_point() const{
 }
 
 void Pubkey::_bind_methods() {
-    ClassDB::bind_static_method("Pubkey", D_METHOD("create_with_seed", "basePubkey", "seed", "owner_pubkey"), &Pubkey::create_with_seed);
+    ClassDB::bind_static_method("Pubkey", D_METHOD("new_from_seed", "basePubkey", "seed", "owner_pubkey"), &Pubkey::new_from_seed);
+    ClassDB::bind_static_method("Pubkey", D_METHOD("new_from_string", "from"), &Pubkey::new_from_string);
+    ClassDB::bind_static_method("Pubkey", D_METHOD("new_program_address", "seeds", "program_id"), &Pubkey::new_program_address);
+    ClassDB::bind_static_method("Pubkey", D_METHOD("new_associated_token_address", "wallet_address", "token_mint_address"), &Pubkey::new_associated_token_address);
 
     ClassDB::bind_method(D_METHOD("get_value"), &Pubkey::get_value);
     ClassDB::bind_method(D_METHOD("set_value", "p_value"), &Pubkey::set_value);
@@ -43,7 +46,6 @@ void Pubkey::_bind_methods() {
     ClassDB::bind_method(D_METHOD("create_from_string", "from"), &Pubkey::create_from_string);
     ClassDB::bind_method(D_METHOD("create_program_address", "seeds", "program_id"), &Pubkey::create_program_address);
     ClassDB::bind_method(D_METHOD("get_associated_token_address", "wallet_pubkey", "token_mint_pubkey"), &Pubkey::get_associated_token_address);
-
 }
 
 
@@ -211,7 +213,7 @@ void Pubkey::create_from_array(const unsigned char* data){
     }
 }
 
-Variant Pubkey::create_with_seed(Variant basePubkey, String seed, Variant owner_pubkey){
+Variant Pubkey::new_from_seed(Variant basePubkey, String seed, Variant owner_pubkey){
     Pubkey *res = memnew(Pubkey);
  
     SHA256 hasher;
@@ -234,6 +236,29 @@ Variant Pubkey::create_with_seed(Variant basePubkey, String seed, Variant owner_
     delete[] sha256_hash;
 
     return res;
+}
+
+Variant Pubkey::new_from_string(const String& from){
+    Pubkey *res = memnew(Pubkey);
+    res->set_value(from);
+    return res;
+}
+
+Variant Pubkey::new_program_address(const PackedStringArray seeds, const Variant &program_id){
+    Pubkey *res = memnew(Pubkey);
+    res->create_program_address(seeds, program_id);
+    return res;
+}
+
+Variant Pubkey::new_associated_token_address(const Variant &wallet_address, const Variant &token_mint_address){    
+    PackedStringArray arr;
+    arr.append(wallet_address);
+    arr.append(token_mint_address);
+    arr.append(String(SolanaSDK::SPL_TOKEN_ADDRESS.c_str()));
+
+    String pid = String(SolanaSDK::SPL_ASSOCIATED_TOKEN_ADDRESS.c_str());
+
+    return new_program_address(arr, (Variant*) &pid);
 }
 
 bool Pubkey::create_program_address(const PackedStringArray seeds, const Variant &program_id){

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -87,6 +87,10 @@ void Transaction::create_message(){
             signatures.clear();
             return;
         }
+        if(!Object::cast_to<Instruction>(instructions[i])->is_serializable()){
+            signatures.clear();
+            return;
+        }
     }
     message = memnew(Message(instructions, payer));
     Object::cast_to<Message>(message)->set_latest_blockhash(latest_blockhash_string);


### PR DESCRIPTION
The creat program address methods are inaccessible from GDScript. This binds static Pubkey methods to create various kinds of keys. It also introduces other convinient create methods to the GDScript interface.