### PR TITLE
Add AssociatedTokenAccountProgram node

### DIFF
--- a/instructions/include/associated_token_account.hpp
+++ b/instructions/include/associated_token_account.hpp
@@ -1,0 +1,25 @@
+#ifndef SOLANA_SDK_ASSOCIATED_TOKEN_ACCOUNT_HPP
+#define SOLANA_SDK_ASSOCIATED_TOKEN_ACCOUNT_HPP
+
+#include <godot_cpp/classes/node.hpp>
+#include <instruction.hpp>
+
+namespace godot{
+
+class AssociatedTokenAccountProgram : public Node{
+    GDCLASS(AssociatedTokenAccountProgram, Node)
+private:
+
+protected:
+    static void _bind_methods();
+
+public:
+    static const std::string ID;
+
+    static Variant create_associated_token_account(const Variant &payer, const Variant &wallet_address, const Variant& mint_address, const Variant& token_program_id);
+    static Variant get_pid();
+};
+
+}
+
+#endif

--- a/instructions/src/associated_token_account.cpp
+++ b/instructions/src/associated_token_account.cpp
@@ -1,0 +1,42 @@
+#include "associated_token_account.hpp"
+#include "system_program.hpp"
+#include "spl_token.hpp"
+
+namespace godot{
+
+const std::string AssociatedTokenAccountProgram::ID = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL";
+
+void AssociatedTokenAccountProgram::_bind_methods(){
+    ClassDB::bind_static_method("AssociatedTokenAccountProgram", D_METHOD("create_associated_token_account", "payer", "wallet_address", "mint_address", "token_program_id"), &AssociatedTokenAccountProgram::create_associated_token_account);
+    ClassDB::bind_static_method("AssociatedTokenAccountProgram", D_METHOD("get_pid"), &AssociatedTokenAccountProgram::get_pid);
+}
+
+Variant AssociatedTokenAccountProgram::create_associated_token_account(const Variant &payer, const Variant &wallet_address, const Variant& mint_address, const Variant& token_program_id){
+    Instruction *result = memnew(Instruction);
+    PackedByteArray data;
+    data.resize(1);
+
+    data[0] = 0;
+
+    const Variant new_pid = memnew(Pubkey(String(ID.c_str())));
+    result->set_program_id(new_pid);
+    result->set_data(data);
+
+    Variant ata = Pubkey::new_associated_token_address(wallet_address, mint_address);
+
+    result->append_meta(AccountMeta(payer, true, true));
+    result->append_meta(AccountMeta(ata, false, true));
+    result->append_meta(AccountMeta(wallet_address, false, false));
+    result->append_meta(AccountMeta(mint_address, false, false));
+    result->append_meta(AccountMeta(payer, true, true));
+    result->append_meta(AccountMeta(SystemProgram::get_pid(), false, false));
+    result->append_meta(AccountMeta(TokenProgram::get_pid(), false, false));
+
+    return result;
+}
+
+Variant AssociatedTokenAccountProgram::get_pid(){
+    return Pubkey::new_from_string(ID.c_str());
+}
+
+}

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -17,6 +17,7 @@
 #include "spl_token.hpp"
 #include "meta_data.hpp"
 #include "mpl_token_metadata.hpp"
+#include "associated_token_account.hpp"
 
 #include <gdextension_interface.h>
 #include <godot_cpp/core/defs.hpp>
@@ -50,6 +51,7 @@ void initialize_solana_sdk_module(ModuleInitializationLevel p_level) {
     ClassDB::register_class<MetaDataCollection>();
     ClassDB::register_class<MetaDataUses>();
     ClassDB::register_class<MetaData>();
+    ClassDB::register_class<AssociatedTokenAccountProgram>();
 
     SolanaClient::set_commitment("finalized");
 }


### PR DESCRIPTION
There is no way to actually create the associated token accounts on chain. This commit adds the node to build the instruction for that.