### PR TITLE
Parse creators and collections

### DIFF
--- a/include/meta_data.hpp
+++ b/include/meta_data.hpp
@@ -112,6 +112,9 @@ public:
     void set_seller_fee_basis_points(const uint16_t seller_fee_basis_points);
     uint16_t get_seller_fee_basis_points();
 
+    void add_creator(const Variant& creator);
+    void set_collection(const Variant& collection);
+
     PackedByteArray serialize(const bool is_mutable) const;
 };
 

--- a/include/meta_data.hpp
+++ b/include/meta_data.hpp
@@ -115,7 +115,7 @@ public:
     void add_creator(const Variant& creator);
     Array get_creators();
     void set_collection(const Variant& collection);
-    Array get_collection();
+    Variant get_collection();
 
     PackedByteArray serialize(const bool is_mutable) const;
 };

--- a/include/meta_data.hpp
+++ b/include/meta_data.hpp
@@ -113,7 +113,9 @@ public:
     uint16_t get_seller_fee_basis_points();
 
     void add_creator(const Variant& creator);
+    Array get_creators();
     void set_collection(const Variant& collection);
+    Array get_collection();
 
     PackedByteArray serialize(const bool is_mutable) const;
 };

--- a/include/pubkey.hpp
+++ b/include/pubkey.hpp
@@ -73,6 +73,7 @@ public:
 
     static Variant new_from_seed(Variant basePubkey, String seed, Variant owner_pubkey);
     static Variant new_from_string(const String& from);
+    static Variant new_from_bytes(const PackedByteArray& from);
     static Variant new_program_address(const PackedStringArray seeds, const Variant &program_id);
     static Variant new_associated_token_address(const Variant &wallet_address, const Variant &token_mint_address);
     static Variant new_pda(const PackedStringArray seeds, const Variant &program_id);

--- a/src/meta_data.cpp
+++ b/src/meta_data.cpp
@@ -279,6 +279,14 @@ uint16_t MetaData::get_seller_fee_basis_points(){
     return seller_fee_basis_points;
 }
 
+void MetaData::add_creator(const Variant& creator){
+    creators.append(creator);
+}
+
+void MetaData::set_collection(const Variant& collection){
+    this->collection = collection;
+}
+
 PackedByteArray MetaData::serialize(const bool is_mutable) const{
     PackedByteArray res;
     const uint32_t DATA_LENGTH = 14 + name.length() + symbol.length() + uri.length();

--- a/src/meta_data.cpp
+++ b/src/meta_data.cpp
@@ -290,7 +290,7 @@ Array MetaData::get_creators(){
     return creators;
 }
 
-Array MetaData::get_collection(){
+Variant MetaData::get_collection(){
     return collection;
 }
 

--- a/src/meta_data.cpp
+++ b/src/meta_data.cpp
@@ -131,6 +131,9 @@ void MetaData::_bind_methods(){
     ClassDB::bind_method(D_METHOD("set_symbol", "symbol"), &MetaData::set_symbol);
     ClassDB::bind_method(D_METHOD("get_uri"), &MetaData::get_uri);
     ClassDB::bind_method(D_METHOD("set_uri", "uri"), &MetaData::set_uri);
+
+    ClassDB::bind_method(D_METHOD("get_creators"), &MetaData::get_creators);
+    ClassDB::bind_method(D_METHOD("get_collection"), &MetaData::get_collection);
 }
 
 bool MetaData::_set(const StringName &p_name, const Variant &p_value){
@@ -281,6 +284,14 @@ uint16_t MetaData::get_seller_fee_basis_points(){
 
 void MetaData::add_creator(const Variant& creator){
     creators.append(creator);
+}
+
+Array MetaData::get_creators(){
+    return creators;
+}
+
+Array MetaData::get_collection(){
+    return collection;
 }
 
 void MetaData::set_collection(const Variant& collection){

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -22,6 +22,7 @@ bool Pubkey::are_bytes_curve_point() const{
 void Pubkey::_bind_methods() {
     ClassDB::bind_static_method("Pubkey", D_METHOD("new_from_seed", "basePubkey", "seed", "owner_pubkey"), &Pubkey::new_from_seed);
     ClassDB::bind_static_method("Pubkey", D_METHOD("new_from_string", "from"), &Pubkey::new_from_string);
+    ClassDB::bind_static_method("Pubkey", D_METHOD("new_from_bytes", "from"), &Pubkey::new_from_bytes);
     ClassDB::bind_static_method("Pubkey", D_METHOD("new_program_address", "seeds", "program_id"), &Pubkey::new_program_address);
     ClassDB::bind_static_method("Pubkey", D_METHOD("new_associated_token_address", "wallet_address", "token_mint_address"), &Pubkey::new_associated_token_address);
     ClassDB::bind_static_method("Pubkey", D_METHOD("new_pda", "seeds", "program_id"), &Pubkey::new_pda);
@@ -242,6 +243,12 @@ Variant Pubkey::new_from_seed(Variant basePubkey, String seed, Variant owner_pub
 Variant Pubkey::new_from_string(const String& from){
     Pubkey *res = memnew(Pubkey);
     res->set_value(from);
+    return res;
+}
+
+Variant Pubkey::new_from_bytes(const PackedByteArray& from){
+    Pubkey *res = memnew(Pubkey);
+    res->set_bytes(from);
     return res;
 }
 

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -53,7 +53,7 @@ void initialize_solana_sdk_module(ModuleInitializationLevel p_level) {
     ClassDB::register_class<MetaData>();
     ClassDB::register_class<AssociatedTokenAccountProgram>();
 
-    SolanaClient::set_commitment("finalized");
+    SolanaClient::set_commitment("confirmed");
     SolanaClient::set_encoding("base64");
 }
 


### PR DESCRIPTION
The metadata parsed from account data does not include creators or collections. This commit adds support by adding these properties to get_metadata method.