### PR TITLE
Add common SolanaClient URL

### DIFF
--- a/example/SolanaClient/SolanaClientExamples.gd
+++ b/example/SolanaClient/SolanaClientExamples.gd
@@ -32,7 +32,7 @@ func add_solana_client() -> SolanaClient:
 	res.async = true
 	
 	# RPC HTTP URL goes here.
-	res.url = "http://127.0.0.1:8899"
+	#res.url = "http://127.0.0.1:8899"
 
 	# Solana Client needs to be in scene tree for async to work.
 	add_child(res)

--- a/example/SolanaClient/project.godot
+++ b/example/SolanaClient/project.godot
@@ -14,8 +14,13 @@ config/name="SolanaClient"
 run/main_scene="res://solana_client_examples.tscn"
 config/features=PackedStringArray("4.2", "GL Compatibility")
 config/icon="res://icon.svg"
+config/property_name=0
 
 [rendering]
 
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"
+
+[solana_sdk]
+
+client/default_url="http://127.0.0.1:8899"

--- a/example/Transactions/project.godot
+++ b/example/Transactions/project.godot
@@ -19,3 +19,7 @@ config/icon="res://icon.svg"
 
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"
+
+[solana_sdk]
+
+client/default_url="http://127.0.0.1:8899"

--- a/example/Transactions/transaction_example.gd
+++ b/example/Transactions/transaction_example.gd
@@ -36,7 +36,6 @@ func transaction_example_transfer():
 	var receiver: Pubkey = Pubkey.new_from_string("78GVwUb8ojcJVrEVkwCU5tfUKTfJuiazRrysGwgjqsif")
 	var tx = Transaction.new()
 
-	tx.set_url("http://127.0.0.1:8899")
 	add_child(tx)
 	
 	# A transaction can be sent after three steps:
@@ -70,7 +69,6 @@ func create_account_example():
 	
 	var account_key: Keypair = Keypair.new_random()
 	var tx = Transaction.new()
-	tx.set_url("http://127.0.0.1:8899")
 	
 	add_child(tx)
 	tx.set_payer(payer)

--- a/example/Transactions/transaction_example.tscn
+++ b/example/Transactions/transaction_example.tscn
@@ -36,8 +36,6 @@ text = "CreateAccount Signature:
 horizontal_alignment = 1
 
 [node name="SolanaClient" type="SolanaClient" parent="."]
-url = "http://127.0.0.1:8899"
-ws_url = "ws://"
 
 [node name="Timeout" type="Timer" parent="."]
 wait_time = 10.0

--- a/include/solana_client.hpp
+++ b/include/solana_client.hpp
@@ -19,8 +19,8 @@ private:
     const std::string DEFAULT_URL = "https://api.devnet.solana.com";
     const std::string DEFAULT_WS_URL = "wss://api.devnet.solana.com";
 
-    String url = "https://api.devnet.solana.com";
-    String ws_url = "wss://api.devnet.solana.com";
+    String url_override = "";
+    String ws_url = "";
     std::string http_request_body;
     int port = DEFAULT_PORT;
     bool use_tls = true;
@@ -50,6 +50,10 @@ private:
     bool max_transaction_version_enabled = false;
     bool rewards = false;
     bool slot_range_enabled = false;
+
+    String ws_from_http(const String& http_url);
+    String get_real_url();
+    String get_real_ws_url();
 
     void append_commitment(Array& options);
     void append_min_context_slot(Array& options);
@@ -91,8 +95,8 @@ public:
 
     SolanaClient();
 
-    void set_url(const String& url);
-    String get_url();
+    void set_url_override(const String& url);
+    String get_url_override();
     
     void set_ws_url(const String& url);
     String get_ws_url();

--- a/include/transaction.hpp
+++ b/include/transaction.hpp
@@ -29,7 +29,7 @@ private:
     String latest_blockhash_string = "";
     String result_signature = "";
     String latest_commitment = "";
-    String url = "https://api.devnet.solana.com";
+    String url_override = "";
 
     SolanaClient *send_client;
     SolanaClient *blockhash_client;
@@ -64,7 +64,7 @@ public:
     void set_payer(const Variant& p_value);
     Variant get_payer();
 
-    void set_url(const String& p_value);
+    void set_url_override(const String& p_value);
 
     bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;

--- a/instructions/include/mpl_token_metadata.hpp
+++ b/instructions/include/mpl_token_metadata.hpp
@@ -24,8 +24,8 @@ public:
     void _process(double delta) override;
     MplTokenMetadata();
 
-    void set_url(const String& url);
-    String get_url();
+    void set_url_override(const String& url_override);
+    String get_url_override();
 
     static const std::string ID;
 

--- a/instructions/src/mpl_token_metadata.cpp
+++ b/instructions/src/mpl_token_metadata.cpp
@@ -23,8 +23,8 @@ void MplTokenMetadata::_process(double delta){
 void MplTokenMetadata::_bind_methods(){
     ClassDB::add_signal("MplTokenMetadata", MethodInfo("metadata_fetched", PropertyInfo(Variant::OBJECT, "metadata")));
 
-    ClassDB::bind_method(D_METHOD("set_url", "url"), &MplTokenMetadata::set_url);
-    ClassDB::bind_method(D_METHOD("get_url"), &MplTokenMetadata::get_url);
+    ClassDB::bind_method(D_METHOD("set_url_override", "url_override"), &MplTokenMetadata::set_url_override);
+    ClassDB::bind_method(D_METHOD("get_url_override"), &MplTokenMetadata::get_url_override);
 
     ClassDB::bind_static_method("MplTokenMetadata", D_METHOD("new_associated_metadata_pubkey", "mint"), &MplTokenMetadata::new_associated_metadata_pubkey);
     ClassDB::bind_static_method("MplTokenMetadata", D_METHOD("new_associated_metadata_pubkey_master_edition", "mint"), &MplTokenMetadata::new_associated_metadata_pubkey_master_edition);
@@ -37,7 +37,7 @@ void MplTokenMetadata::_bind_methods(){
 
     ClassDB::bind_static_method("MplTokenMetadata", D_METHOD("get_pid"), &MplTokenMetadata::get_pid);
 
-    ClassDB::add_property("MplTokenMetadata", PropertyInfo(Variant::STRING, "url", PROPERTY_HINT_NONE), "set_url", "get_url");
+    ClassDB::add_property("MplTokenMetadata", PropertyInfo(Variant::STRING, "url_override", PROPERTY_HINT_NONE), "set_url_override", "get_url_override");
 }
 
 Variant MplTokenMetadata::new_associated_metadata_pubkey(const Variant& mint){
@@ -277,12 +277,12 @@ Variant MplTokenMetadata::get_pid(){
     return Pubkey::new_from_string(ID.c_str());
 }
 
-void MplTokenMetadata::set_url(const String& url){
-    metadata_client->set_url(url);
+void MplTokenMetadata::set_url_override(const String& url_override){
+    metadata_client->set_url_override(url_override);
 }
 
-String MplTokenMetadata::get_url(){
-    return metadata_client->get_url();
+String MplTokenMetadata::get_url_override(){
+    return metadata_client->get_url_override();
 }
 
 }

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -25,8 +25,28 @@
 #include <godot_cpp/core/defs.hpp>
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/godot.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
 
 using namespace godot;
+
+void add_setting(const String& name, Variant::Type type, Variant default_value, PropertyHint hint = PropertyHint::PROPERTY_HINT_NONE, const String& hint_string = ""){
+    if(!ProjectSettings::get_singleton()->has_setting(name)){
+        ProjectSettings::get_singleton()->set(name, default_value);
+
+        ProjectSettings::get_singleton()->set_initial_value(name, default_value);
+        ProjectSettings::get_singleton()->set_as_basic(name, true);
+
+        Dictionary property_info;
+        property_info["name"] = name;
+        property_info["type"] = type;
+        property_info["hint"] = hint;
+        property_info["hint_string"] = hint_string;
+
+        ProjectSettings::get_singleton()->add_property_info(property_info);
+
+        ProjectSettings::get_singleton()->save();
+    }
+}
 
 void initialize_solana_sdk_module(ModuleInitializationLevel p_level) {
     if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
@@ -59,6 +79,8 @@ void initialize_solana_sdk_module(ModuleInitializationLevel p_level) {
     ClassDB::register_class<CandyGuardAccessList>();
     ClassDB::register_class<CandyMachineData>();
     ClassDB::register_class<AnchorProgram>();
+
+    add_setting("solana_sdk/client/default_url", Variant::Type::STRING, "https://api.devnet.solana.com");
 }
 
 void uninitialize_solana_sdk_module(ModuleInitializationLevel p_level) {

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -28,7 +28,7 @@ void Transaction::_bind_methods() {
     ClassDB::add_signal("Transaction", MethodInfo("blockhash_updated", PropertyInfo(Variant::DICTIONARY, "result")));
     ClassDB::add_signal("Transaction", MethodInfo("blockhash_update_failure", PropertyInfo(Variant::DICTIONARY, "result")));
 
-    ClassDB::bind_method(D_METHOD("set_url", "url"), &Transaction::set_url);
+    ClassDB::bind_method(D_METHOD("set_url_override", "url_override"), &Transaction::set_url_override);
 
     ClassDB::bind_method(D_METHOD("get_instructions"), &Transaction::get_instructions);
     ClassDB::bind_method(D_METHOD("set_instructions", "p_value"), &Transaction::set_instructions);
@@ -174,8 +174,8 @@ bool Transaction::_set(const StringName &p_name, const Variant &p_value){
         set_external_payer(p_value);
         return true;
     }
-    else if(name == "url"){
-        set_url(p_value);
+    else if(name == "url_override"){
+        set_url_override(p_value);
         return true;
     }
     else if(name == "unit_limit"){
@@ -207,8 +207,8 @@ bool Transaction::_get(const StringName &p_name, Variant &r_ret) const{
         r_ret = external_payer;
         return true;
     }
-    else if(name == "url"){
-        r_ret = url;
+    else if(name == "url_override"){
+        r_ret = url_override;
         return true;
     }
     else if(name == "unit_limit"){
@@ -223,7 +223,7 @@ bool Transaction::_get(const StringName &p_name, Variant &r_ret) const{
 }
 
 void Transaction::_get_property_list(List<PropertyInfo> *p_list) const {
-    p_list->push_back(PropertyInfo(Variant::STRING, "url"));
+    p_list->push_back(PropertyInfo(Variant::STRING, "url_override"));
     p_list->push_back(PropertyInfo(Variant::BOOL, "external_payer", PROPERTY_HINT_NONE, "false"));
     if(!external_payer){
         p_list->push_back(PropertyInfo(Variant::OBJECT, "payer", PROPERTY_HINT_RESOURCE_TYPE, "Pubkey,Keypair"));
@@ -317,10 +317,10 @@ Variant Transaction::get_payer(){
     return payer;
 }
 
-void Transaction::set_url(const String& p_value){
-    url = p_value;
-    send_client->set_url(url);
-    blockhash_client->set_url(url);
+void Transaction::set_url_override(const String& p_value){
+    url_override = p_value;
+    send_client->set_url_override(url_override);
+    blockhash_client->set_url_override(url_override);
 }
 
 void Transaction::set_external_payer(bool p_value){


### PR DESCRIPTION
The URL must be set for all client instances and also transactions. This commit fixes this by adding a project setting for the URL. The other nodes have URL override properties instead to set individual URLs.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
