### PR TITLE
Add mint to and config line sample code

### DIFF
--- a/example/CandyMachine/candy_machine_data.tres
+++ b/example/CandyMachine/candy_machine_data.tres
@@ -1,8 +1,8 @@
 [gd_resource type="CandyMachineData" load_steps=4 format=3 uid="uid://dgroc4gnyxfai"]
 
 [sub_resource type="ConfigLineSetting" id="ConfigLineSetting_ckrsi"]
-prefix_name = "hello#"
-name_length = 10
+prefix_name = "test_prefix#"
+name_length = 15
 prefix_uri = "abc"
 uri_length = 22
 is_sequential = true
@@ -18,7 +18,7 @@ share = 100
 
 [resource]
 items_available = 1
+symbol = "GSS"
 seller_fee_basis_points = 800
-max_supply = 1
 creators = [SubResource("MetaDataCreator_hghpc")]
 config_line_setting = SubResource("ConfigLineSetting_ckrsi")

--- a/example/CandyMachine/candy_machine_demo.gd
+++ b/example/CandyMachine/candy_machine_demo.gd
@@ -1,10 +1,9 @@
 extends Control
 
 const MINT_SIZE := 82
-const CANDY_MACHINE_SIZE := 951
 const MINT_ACCOUNT_SIZE := 165
 
-const TOTAL_CASES := 2
+const TOTAL_CASES := 4
 var passed_test_mask := 0
 var payer: Keypair = await Keypair.new_from_file("payer.json")
 
@@ -56,7 +55,7 @@ func initialize_mint_collection_demo():
 	tx.add_instruction(ix)
 	ix = MplTokenMetadata.update_metadata_account(MplTokenMetadata.new_associated_metadata_pubkey(mint_keypair), payer)
 	tx.add_instruction(ix)
-	ix = MplTokenMetadata.create_master_edition(mint_keypair, payer, payer, payer, 1)
+	ix = MplTokenMetadata.create_master_edition(mint_keypair, payer, payer, payer, 0)
 	tx.add_instruction(ix)
 	
 	tx.set_payer(payer)
@@ -73,15 +72,16 @@ func initialize_mint_collection_demo():
 	
 
 func initialize_candy_machine_demo():
-	var candy_machine_lamports = await minumum_balance_for_rent_extemtion(CANDY_MACHINE_SIZE)
+	var candy_machine_size = load("res://candy_machine_data.tres").get_space_for_candy()
+	var candy_machine_lamports = await minumum_balance_for_rent_extemtion(candy_machine_size)
 	
-		# Create a transaction
+	# Create a transaction
 	var tx := Transaction.new()
 	add_child(tx)
 	
-	var ix: Instruction = SystemProgram.create_account(payer, candy_machine_keypair, candy_machine_lamports, CANDY_MACHINE_SIZE, MplCandyMachine.get_pid())
+	var ix: Instruction = SystemProgram.create_account(payer, candy_machine_keypair, candy_machine_lamports, candy_machine_size, MplCandyMachine.get_pid())
 	tx.add_instruction(ix)
-	ix = MplCandyMachine.initialize(payer, candy_machine_keypair, mint_keypair, load("res://candy_machine_data.tres"))
+	ix = MplCandyMachine.initialize(payer, candy_machine_keypair, mint_keypair, load("res://candy_machine_data.tres"), true)
 	tx.add_instruction(ix)
 	
 	tx.set_payer(payer)
@@ -89,7 +89,6 @@ func initialize_candy_machine_demo():
 
 	tx.sign_and_send()
 	var result = await tx.transaction_response_received
-
 	assert(result.has("result"))
 
 	await tx.confirmed
@@ -97,10 +96,70 @@ func initialize_candy_machine_demo():
 	PASS(1)
 
 
+func add_config_line_demo():
+	# Create a transaction
+	var tx := Transaction.new()
+	add_child(tx)
+	
+	var config_lines = [
+		load("res://config_lines/1.tres"),
+	]
+	
+	var ix: Instruction = MplCandyMachine.add_config_lines(candy_machine_keypair, payer, config_lines, 0)
+	tx.add_instruction(ix)
+	
+	tx.set_payer(payer)
+	tx.update_latest_blockhash()
+
+	tx.sign_and_send()
+	var result = await tx.transaction_response_received
+	assert(result.has("result"))
+
+	await tx.confirmed
+
+	PASS(2)
+
+
+func mint_demo():
+	var nft_keypair: Keypair = Keypair.new_random()
+	var random_receiver: Pubkey = Pubkey.new_associated_token_address(payer, nft_keypair)
+
+	# Create a transaction
+	var tx := Transaction.new()
+	add_child(tx)
+
+	var ix: Instruction = MplCandyMachine.mint(payer, payer, nft_keypair, mint_keypair, payer, candy_machine_keypair)
+	tx.add_instruction(ix)
+	
+	tx.set_payer(payer)
+	tx.update_latest_blockhash()
+
+	tx.sign_and_send()
+	var result = await tx.transaction_response_received
+	assert(result.has("result"))
+
+	await tx.confirmed
+
+	PASS(3)
+
+
+func fetch_candy_machine_account_demo():
+	$MplCandyMachine.get_candy_machine_info(candy_machine_keypair);
+	var candy_machine_data: CandyMachineData = await $MplCandyMachine.account_fetched
+	assert(candy_machine_data.token_standard == 4) # Make sure token standard is pnft.
+	assert(candy_machine_data.symbol == "GSS")
+	assert(candy_machine_data.seller_fee_basis_points == 800)
+	PASS(4)
+
+
 func _ready():
 	# Use created mint in upcoming transactions, so await it.
 	await initialize_mint_collection_demo()
-	initialize_candy_machine_demo()
+	await initialize_candy_machine_demo()
+	await add_config_line_demo()
+	await mint_demo()
+	fetch_candy_machine_account_demo()
+	
 
 
 func _on_timeout_timeout():

--- a/example/CandyMachine/candy_machine_demo.tscn
+++ b/example/CandyMachine/candy_machine_demo.tscn
@@ -16,4 +16,6 @@ wait_time = 10.0
 one_shot = true
 autostart = true
 
+[node name="MplCandyMachine" type="MplCandyMachine" parent="."]
+
 [connection signal="timeout" from="Timeout" to="." method="_on_timeout_timeout"]

--- a/example/CandyMachine/config_lines/1.tres
+++ b/example/CandyMachine/config_lines/1.tres
@@ -1,0 +1,5 @@
+[gd_resource type="ConfigLine" format=3 uid="uid://sesikyny42c8"]
+
+[resource]
+name = "test_nft1"
+uri = "test_uri1"

--- a/example/CandyMachine/meta_data.tres
+++ b/example/CandyMachine/meta_data.tres
@@ -1,6 +1,17 @@
-[gd_resource type="MetaData" format=3 uid="uid://g4vjuu02dtw0"]
+[gd_resource type="MetaData" load_steps=3 format=3 uid="uid://g4vjuu02dtw0"]
+
+[sub_resource type="Pubkey" id="Pubkey_l1rv4"]
+type = "CUSTOM"
+value = "11111111111111111111111111111111"
+bytes = PackedByteArray(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+
+[sub_resource type="MetaDataCreator" id="MetaDataCreator_ivwah"]
+address = SubResource("Pubkey_l1rv4")
+share = 100
 
 [resource]
 name = "my_coin"
 symbol = "mc"
 uri = "abc"
+enable_creators = true
+creators = [SubResource("MetaDataCreator_ivwah")]

--- a/include/transaction.hpp
+++ b/include/transaction.hpp
@@ -45,6 +45,8 @@ private:
     bool pending_blockhash = false;
     bool pending_send = false;
 
+    bool skip_preflight = true;
+
     bool are_all_bytes_zeroes(const PackedByteArray& bytes);
 
     void _get_property_list(List<PropertyInfo> *p_list) const;

--- a/instructions/include/mpl_candy_machine.hpp
+++ b/instructions/include/mpl_candy_machine.hpp
@@ -6,12 +6,34 @@
 #include <godot_cpp/classes/resource.hpp>
 #include <godot_cpp/classes/node.hpp>
 #include <account_meta.hpp>
+#include <solana_client.hpp>
 
 namespace godot{
 
 class CandyGuardAccessList;
 
 MAKE_TYPED_ARRAY(CandyGuardAccessList, Variant::OBJECT)
+
+class ConfigLine: public Resource{
+    GDCLASS(ConfigLine, Resource)
+private:
+    String name;
+    String uri;
+protected:
+    static void _bind_methods();
+public:
+    ConfigLine();
+
+    void set_name(const String &value);
+    String get_name();
+
+    void set_uri(const String &value);
+    String get_uri();
+
+    PackedByteArray serialize();
+    ~ConfigLine();
+};
+
 
 class ConfigLineSetting : public Resource{
     GDCLASS(ConfigLineSetting, Resource)
@@ -65,6 +87,8 @@ private:
     Variant config_line_setting = nullptr;
     Variant hidden_settings = nullptr;
 
+    unsigned int get_config_line_size();
+
 protected:
     static void _bind_methods();
 public:
@@ -109,6 +133,7 @@ public:
     Variant get_config_line_setting();
 
     PackedByteArray serialize();
+    unsigned int get_space_for_candy(); 
 };
 
 class CandyGuardAccessList: public Resource{
@@ -213,15 +238,21 @@ public:
 class MplCandyMachine : public Node{
     GDCLASS(MplCandyMachine, Node)
 private:
+    SolanaClient* fetch_client;
 
 protected:
     static void _bind_methods();
 
 public:
+    MplCandyMachine();
+
+    void _process(float delta);
+
     static PackedByteArray mint_discriminator();
     static PackedByteArray mint2_discriminator();
     static PackedByteArray initialize_discriminator();
     static PackedByteArray initialize2_discriminator();
+    static PackedByteArray add_config_lines_discriminator();
 
     static const std::string ID;
 
@@ -240,8 +271,16 @@ public:
         const Variant &collection_update_authority,
         const Variant &candy_machine_key);
 
+    static Variant add_config_lines(
+        const Variant &candy_machine_key,
+        const Variant &authority,
+        const Array &config_lines,
+        const unsigned int index
+    );
+
     static Variant new_candy_machine_authority_pda(const Variant& candy_machine_key);
-    static Variant get_candy_machine_info(const Variant& candy_machine_key);
+    Variant get_candy_machine_info(const Variant& candy_machine_key);
+    void fetch_account_callback(const Dictionary& params);
     static Variant get_pid();
 };
 

--- a/instructions/include/spl_token.hpp
+++ b/instructions/include/spl_token.hpp
@@ -22,7 +22,7 @@ public:
     };
 
     static const std::string ID;
-    static Variant new_token_record_address(const Variant &owner_account, const Variant &mint);
+    static Variant new_token_record_address(const Variant &token, const Variant &mint);
     static Variant new_delegate_record_address(const Variant& update_authority, const Variant &mint, const Variant& delegate_address, const MetaDataDelegateRole role);
 
     static Variant initialize_mint(const Variant& mint_pubkey, const Variant& mint_authority, const Variant& freeze_authority = nullptr, const uint32_t decimals = 9);

--- a/src/anchor_program.cpp
+++ b/src/anchor_program.cpp
@@ -230,8 +230,6 @@ AnchorProgram::AnchorProgram(){
 void AnchorProgram::_process(double delta){
     idl_client->_process(delta);
     fetch_client->_process(delta);
-    idl_client->set_async_override(true);
-    fetch_client->set_async_override(true);
 }
 
 PackedByteArray AnchorProgram::serialize_variant(const Variant &var){

--- a/src/meta_data.cpp
+++ b/src/meta_data.cpp
@@ -321,13 +321,14 @@ PackedByteArray MetaData::serialize(const bool is_mutable) const{
     res.encode_u16(data_location, seller_fee_basis_points);
 
     res.append((int) (enable_creators && !creators.is_empty()));
-    if(enable_collection && !creators.is_empty()){
+    if(enable_creators && !creators.is_empty()){
         PackedByteArray serialized_creators;
         serialized_creators.resize(4);
         serialized_creators.encode_u32(0, creators.size());
         for(unsigned int i = 0; i < creators.size(); i++){
             const MetaDataCreator *creators_ptr = Object::cast_to<MetaDataCreator>(creators[i]);
             const PackedByteArray serialized_collection = creators_ptr->serialize();
+            serialized_creators.append_array(serialized_collection);
         }
         res.append_array(serialized_creators);
     }

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -79,6 +79,7 @@ void initialize_solana_sdk_module(ModuleInitializationLevel p_level) {
     ClassDB::register_class<CandyGuardAccessList>();
     ClassDB::register_class<CandyMachineData>();
     ClassDB::register_class<ConfigLineSetting>();
+    ClassDB::register_class<ConfigLine>();
     ClassDB::register_class<AnchorProgram>();
 
     add_setting("solana_sdk/client/default_url", Variant::Type::STRING, "https://api.devnet.solana.com");

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -588,7 +588,7 @@ Dictionary Transaction::send(){
 
     if(!is_inside_tree()){
         WARN_PRINT_ED("Using synchronous network calls. Consider adding Transaction to scene tree for asynchronous requests.");
-        Dictionary rpc_result = send_client->send_transaction(SolanaUtils::bs64_encode(serialized_bytes));
+        Dictionary rpc_result = send_client->send_transaction(SolanaUtils::bs64_encode(serialized_bytes), skip_preflight);
 
         send_callback(rpc_result);
 
@@ -609,7 +609,7 @@ Dictionary Transaction::send(){
 
         pending_send = true;
         send_client->connect("http_response_received", callback);
-        Dictionary rpc_result = send_client->send_transaction(SolanaUtils::bs64_encode(serialized_bytes));
+        Dictionary rpc_result = send_client->send_transaction(SolanaUtils::bs64_encode(serialized_bytes), skip_preflight);
 
         return Dictionary();
     }


### PR DESCRIPTION
The candy machine is incomplete and did not show how the candy machine could be used to mint from. This commit adds the sample code and also adds an instruction for config lines and a space calculation method.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
