### PR TITLE
Add inheritance of SolanaClient node

### DIFF
--- a/example/SolanaClient/SolanaClientExamples.gd
+++ b/example/SolanaClient/SolanaClientExamples.gd
@@ -28,11 +28,8 @@ func display_dict(data: Variant, parent: TreeItem):
 func add_solana_client() -> SolanaClient:
 	var res = SolanaClient.new()
 	
-	# Async is true by default
-	res.async = true
-	
-	# RPC HTTP URL goes here.
-	#res.url = "http://127.0.0.1:8899"
+	# RPC HTTP URL is set in project settings.
+	# You can override it by setting url_override property.
 
 	# Solana Client needs to be in scene tree for async to work.
 	add_child(res)
@@ -95,7 +92,6 @@ func synchronous_client_call():
 	var client = SolanaClient.new()
 	var response = client.get_account_info(EXAMPLE_ACCOUNT)
 	assert(response.has("result"))
-	print(response)
 	display_dict(response["result"], $ResultTree4.create_item())
 	PASS(6)
 

--- a/include/solana_client.hpp
+++ b/include/solana_client.hpp
@@ -13,7 +13,11 @@ class SolanaClient : public Node {
 
 private:
     static unsigned int global_rpc_id;
+
     unsigned int local_rpc_id = 0;
+    
+    float timeout = 10.0;
+    float elapsed_time = 0;
 
     const int DEFAULT_PORT = 443;
     const std::string DEFAULT_URL = "https://api.devnet.solana.com";
@@ -71,15 +75,13 @@ private:
 
     Dictionary make_rpc_dict(const String& method, const Array& params);
     Dictionary make_rpc_param(const Variant& key, const Variant& value);
-    Dictionary make_rpc_param(const Variant& key, const Dictionary& value);
-    Dictionary make_data_slice(uint64_t offset, uint64_t length);
     Dictionary synchronous_request(const String& request_body);
     void asynchronous_request(const String& request_body);
     Dictionary quick_http_request(const String& request_body, const Callable& callback = Callable());
     Dictionary parse_url(const String& url);
     String assemble_url(const Dictionary& url_components);
 
-    void poll_http_request();
+    void poll_http_request(const float delta);
 
     void process_package(const PackedByteArray& packet_data);
     void connect_ws();
@@ -97,6 +99,9 @@ public:
 
     void set_url_override(const String& url);
     String get_url_override();
+
+    void set_timeout(float timeout);
+    float get_timeout();
     
     void set_ws_url(const String& url);
     String get_ws_url();

--- a/instructions/include/mpl_candy_machine.hpp
+++ b/instructions/include/mpl_candy_machine.hpp
@@ -235,18 +235,15 @@ public:
     TypedArray<AccountMeta> get_mint_arg_accounts(const Variant& payer);
 };
 
-class MplCandyMachine : public Node{
-    GDCLASS(MplCandyMachine, Node)
+class MplCandyMachine : public SolanaClient{
+    GDCLASS(MplCandyMachine, SolanaClient)
 private:
-    SolanaClient* fetch_client;
 
 protected:
     static void _bind_methods();
 
 public:
     MplCandyMachine();
-
-    void _process(float delta);
 
     static PackedByteArray mint_discriminator();
     static PackedByteArray mint2_discriminator();

--- a/instructions/include/mpl_token_metadata.hpp
+++ b/instructions/include/mpl_token_metadata.hpp
@@ -9,11 +9,10 @@
 
 namespace godot{
 
-class MplTokenMetadata : public Node{
-    GDCLASS(MplTokenMetadata, Node)
+class MplTokenMetadata : public SolanaClient{
+    GDCLASS(MplTokenMetadata, SolanaClient)
 private:
     bool pending_fetch = false;
-    SolanaClient *metadata_client = nullptr;
 
     void metadata_callback(const Dictionary& rpc_result);
 
@@ -21,11 +20,7 @@ protected:
     static void _bind_methods();
 
 public:
-    void _process(double delta) override;
     MplTokenMetadata();
-
-    void set_url_override(const String& url_override);
-    String get_url_override();
 
     static const std::string ID;
 

--- a/instructions/src/mpl_candy_machine.cpp
+++ b/instructions/src/mpl_candy_machine.cpp
@@ -1257,12 +1257,6 @@ const std::string MplCandyMachine::ID = "CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnj
 const std::string MplCandyGuard::ID = "Guard1JwRhJkVH6XZhzoYxeBVQe872VH6QggF4BWmS9g";
 
 MplCandyMachine::MplCandyMachine(){
-    fetch_client = memnew(SolanaClient);
-    fetch_client->set_async_override(true);
-}
-
-void MplCandyMachine::_process(float delta){
-    fetch_client->_process(delta);
 }
 
 PackedByteArray MplCandyMachine::mint_discriminator(){
@@ -1461,8 +1455,8 @@ Variant MplCandyMachine::new_candy_machine_authority_pda(const Variant& candy_ma
 
 Variant MplCandyMachine::get_candy_machine_info(const Variant& candy_machine_key){
     Callable callback(this, "fetch_account_callback");
-    fetch_client->connect("http_response_received", callback, ConnectFlags::CONNECT_ONE_SHOT);
-    return fetch_client->get_account_info(Pubkey(candy_machine_key).to_string());
+    connect("http_response_received", callback, ConnectFlags::CONNECT_ONE_SHOT);
+    return get_account_info(Pubkey(candy_machine_key).to_string());
 }
 
 void MplCandyMachine::fetch_account_callback(const Dictionary& params){

--- a/instructions/src/mpl_token_metadata.cpp
+++ b/instructions/src/mpl_token_metadata.cpp
@@ -11,22 +11,11 @@ namespace godot{
 const std::string MplTokenMetadata::ID = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s";
 
 MplTokenMetadata::MplTokenMetadata(){
-    metadata_client = memnew(SolanaClient);
-    metadata_client->set_async_override(true);
-}
-
-void MplTokenMetadata::_process(double delta){
-    if(pending_fetch){
-        metadata_client->_process(delta);
-    }
 }
 
 void MplTokenMetadata::_bind_methods(){
     ClassDB::add_signal("MplTokenMetadata", MethodInfo("metadata_fetched", PropertyInfo(Variant::OBJECT, "metadata")));
-
-    ClassDB::bind_method(D_METHOD("set_url_override", "url_override"), &MplTokenMetadata::set_url_override);
-    ClassDB::bind_method(D_METHOD("get_url_override"), &MplTokenMetadata::get_url_override);
-
+    
     ClassDB::bind_static_method("MplTokenMetadata", D_METHOD("new_associated_metadata_pubkey", "mint"), &MplTokenMetadata::new_associated_metadata_pubkey);
     ClassDB::bind_static_method("MplTokenMetadata", D_METHOD("new_associated_metadata_pubkey_master_edition", "mint"), &MplTokenMetadata::new_associated_metadata_pubkey_master_edition);
 
@@ -38,8 +27,6 @@ void MplTokenMetadata::_bind_methods(){
     ClassDB::bind_static_method("MplTokenMetadata", D_METHOD("create_master_edition", "mint", "update_authority", "mint_authority", "payer", "max_supply"), &MplTokenMetadata::create_master_edition);
 
     ClassDB::bind_static_method("MplTokenMetadata", D_METHOD("get_pid"), &MplTokenMetadata::get_pid);
-
-    ClassDB::add_property("MplTokenMetadata", PropertyInfo(Variant::STRING, "url_override", PROPERTY_HINT_NONE), "set_url_override", "get_url_override");
 }
 
 Variant MplTokenMetadata::new_associated_metadata_pubkey(const Variant& mint){
@@ -97,8 +84,8 @@ Variant MplTokenMetadata::get_mint_metadata(const Variant& mint){
     Variant metadata_account = new_associated_metadata_pubkey(mint);
 
     Callable callback(this, "metadata_callback");
-    metadata_client->connect("http_response_received", callback, ConnectFlags::CONNECT_ONE_SHOT);
-    Dictionary rpc_result = metadata_client->get_account_info(Pubkey(metadata_account).to_string());
+    connect("http_response_received", callback, ConnectFlags::CONNECT_ONE_SHOT);
+    Dictionary rpc_result = get_account_info(Pubkey(metadata_account).to_string());
 
     return OK;
 }
@@ -298,14 +285,6 @@ Variant MplTokenMetadata::create_master_edition(const Variant& mint, const Varia
 
 Variant MplTokenMetadata::get_pid(){
     return Pubkey::new_from_string(ID.c_str());
-}
-
-void MplTokenMetadata::set_url_override(const String& url_override){
-    metadata_client->set_url_override(url_override);
-}
-
-String MplTokenMetadata::get_url_override(){
-    return metadata_client->get_url_override();
 }
 
 }


### PR DESCRIPTION
The Nodes that inherit SolanaClient does not expose the properties. This commit modifies all nodes that has internal SolanaClient pointers to instead inherit the node. The SolanaClient node properties are thereby accessable to the user.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
