### PR TITLE
Fix build failing in new scons versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
         shell: bash
         run: |
           python -c "import sys; print(sys.version)"
-          python -m pip install scons
+          python -m pip install scons==4.2
           scons --version
 
       - name: Checkout project

--- a/.github/workflows/run_examples.yml
+++ b/.github/workflows/run_examples.yml
@@ -30,7 +30,7 @@ jobs:
               shell: bash
               run: |
                 python -c "import sys; print(sys.version)"
-                python -m pip install scons
+                python -m pip install scons==4.2
                 scons --version
 
             - uses: chickensoft-games/setup-godot@v1


### PR DESCRIPTION
The build fails in newer version of scons. This commit locks the scons version to 4.2 for workflow jobs.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
