### PR TITLE
Fix error with SolanaClient settings

### DIFF
--- a/example/SolanaClient/SolanaClientExamples.gd
+++ b/example/SolanaClient/SolanaClientExamples.gd
@@ -2,7 +2,7 @@ extends VBoxContainer
 
 const EXAMPLE_ACCOUNT := "4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZAMdL4VZHirAn"
 
-const TOTAL_CASES := 7
+const TOTAL_CASES := 8
 var passed_test_mask := 0
 		
 
@@ -97,12 +97,47 @@ func synchronous_client_call():
 	PASS(6)
 
 
+func test_project_settings():
+	const CORRECT_URL = "http://localhost"
+	const INCORRECT_URL = "nonsense url"
+	const CORRECT_PORT = "8899"
+	const INCORRECT_PORT = "8898"
+	
+	var client = SolanaClient.new()
+	
+	var response = client.get_account_info(EXAMPLE_ACCOUNT)
+	assert(response.has("result"))
+	ProjectSettings.set_setting("solana_sdk/client/default_url", INCORRECT_URL)
+	response = client.get_account_info(EXAMPLE_ACCOUNT)
+	assert(!response.has("result"))
+	ProjectSettings.set_setting("solana_sdk/client/default_url", CORRECT_URL)
+	ProjectSettings.set_setting("solana_sdk/client/default_http_port", CORRECT_PORT)
+	response = client.get_account_info(EXAMPLE_ACCOUNT)
+	assert(response.has("result"))
+	ProjectSettings.set_setting("solana_sdk/client/default_http_port", INCORRECT_PORT)
+	response = client.get_account_info(EXAMPLE_ACCOUNT)
+	assert(!response.has("result"))
+	
+	# Port in URL overrides port setting and triggers a warning.
+	ProjectSettings.set_setting("solana_sdk/client/default_url", CORRECT_URL + ":" + CORRECT_PORT)
+	ProjectSettings.set_setting("solana_sdk/client/default_http_port", INCORRECT_PORT)
+	response = client.get_account_info(EXAMPLE_ACCOUNT)
+	assert(response.has("result"))
+	
+	# Restore correct settings
+	ProjectSettings.set_setting("solana_sdk/client/default_url", CORRECT_URL)
+	ProjectSettings.set_setting("solana_sdk/client/default_http_port", CORRECT_PORT)
+	
+	PASS(7)
+
+
 func _ready():
 	get_account_info_demo()
 	get_latest_blockhash_demo()
 	get_minimum_balance_for_rent_extemption_demo()
 	subscribe_account_demo()
 	synchronous_client_call()
+	test_project_settings()
 
 
 func _account_subscribe_callback(_params):

--- a/example/SolanaClient/project.godot
+++ b/example/SolanaClient/project.godot
@@ -23,4 +23,6 @@ renderer/rendering_method.mobile="gl_compatibility"
 
 [solana_sdk]
 
-client/default_url="http://127.0.0.1:8899"
+client/default_url="http://127.0.0.1"
+client/default_http_port=8899
+client/default_ws_port=8900

--- a/include/solana_client.hpp
+++ b/include/solana_client.hpp
@@ -69,15 +69,15 @@ private:
     float timeout = 20.0;
 
     static unsigned int global_rpc_id;
+    uint32_t http_port_override = 0;
+    uint32_t ws_port_override = 0;
 
-    const int DEFAULT_PORT = 443;
     const std::string DEFAULT_URL = "https://api.devnet.solana.com";
     const std::string DEFAULT_WS_URL = "wss://api.devnet.solana.com";
 
     String url_override = "";
     String ws_url = "";
     
-    int port = DEFAULT_PORT;
     bool use_tls = true;
     bool async_override = false;
     bool pending_request = false;
@@ -100,6 +100,8 @@ private:
 
     String ws_from_http(const String& http_url);
     String get_real_url();
+    uint32_t get_real_http_port();
+    uint32_t get_real_ws_port();
     String get_real_ws_url();
 
     HttpRpcCall *create_http_call();

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -44,8 +44,6 @@ void add_setting(const String& name, Variant::Type type, Variant default_value, 
         property_info["hint_string"] = hint_string;
 
         ProjectSettings::get_singleton()->add_property_info(property_info);
-
-        ProjectSettings::get_singleton()->save();
     }
 }
 
@@ -87,6 +85,8 @@ void initialize_solana_sdk_module(ModuleInitializationLevel p_level) {
     ClassDB::register_class<AnchorProgram>();
 
     add_setting("solana_sdk/client/default_url", Variant::Type::STRING, "https://api.devnet.solana.com");
+    add_setting("solana_sdk/client/default_http_port", Variant::Type::INT, 443);
+    add_setting("solana_sdk/client/default_ws_port", Variant::Type::INT, 443);
 }
 
 void uninitialize_solana_sdk_module(ModuleInitializationLevel p_level) {


### PR DESCRIPTION
The SolanaClient settings were not saving each time and caused annoying popups. This commit fixes this and also adds properties to enable specifying SolanaClient ports and port overrides.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
