### PR TITLE
Fix signer and writable in anchor instructions

### DIFF
--- a/example/SolanaClient/SolanaClientExamples.gd
+++ b/example/SolanaClient/SolanaClientExamples.gd
@@ -2,7 +2,7 @@ extends VBoxContainer
 
 const EXAMPLE_ACCOUNT := "4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZAMdL4VZHirAn"
 
-const TOTAL_CASES := 9
+const TOTAL_CASES := 8
 var passed_test_mask := 0
 		
 

--- a/include/anchor_program.hpp
+++ b/include/anchor_program.hpp
@@ -22,6 +22,9 @@ private:
     SolanaClient *idl_client = nullptr;
     SolanaClient *fetch_client = nullptr;
 
+    bool detect_writable(const Dictionary& account);
+    bool detect_is_signer(const Dictionary& account);
+
     static bool is_typed_primitive(const Dictionary &dict);
     static PackedByteArray serialize_typed_primitive(const Dictionary &dict);
     Variant idl_address(const Variant& pid);

--- a/src/anchor_program.cpp
+++ b/src/anchor_program.cpp
@@ -11,6 +11,30 @@
 
 namespace godot{
 
+bool AnchorProgram::detect_writable(const Dictionary& account){
+    if(account.has("isMut")){
+        return account["isMut"];
+    }
+    else if(account.has("writable")){
+        return account["writable"];
+    }
+    else{
+        return false;
+    }
+}
+
+bool AnchorProgram::detect_is_signer(const Dictionary& account){
+    if(account.has("isSigner")){
+        return account["isSigner"];
+    }
+    else if(account.has("signer")){
+        return account["signer"];
+    }
+    else{
+        return false;
+    }
+}
+
 bool AnchorProgram::is_typed_primitive(const Dictionary &dict){
     return (dict.has("dataType") && dict.has("value") && dict.keys().size() && dict["dataType"] != String("option"));
 }
@@ -841,8 +865,8 @@ Variant AnchorProgram::build_instruction(String name, Array accounts, Variant ar
     Array ref_accounts = instruction_info["accounts"];
 
     for(unsigned int i = 0; i < ref_accounts.size(); i++){
-        const bool writable = ((Dictionary)ref_accounts[i])["isMut"];
-        const bool is_signer = ((Dictionary)ref_accounts[i])["isSigner"];
+        const bool writable = detect_writable(ref_accounts[i]);
+        const bool is_signer = detect_is_signer(ref_accounts[i]);
         result->append_meta(AccountMeta::new_account_meta(accounts[i], is_signer, writable));
     }
 


### PR DESCRIPTION
The idl name seems to have updated some time ago. This commit adds support for new account data in the instructions. This makes the SDK able to determine if the account is signer and writable again.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
