### PR TITLE
Remove instruction checks on update blockhash

### DIFF
--- a/example/Transactions/transaction_example.gd
+++ b/example/Transactions/transaction_example.gd
@@ -4,7 +4,7 @@ extends VBoxContainer
 @onready var payer: Keypair = Keypair.new_from_file("res://payer.json")
 const LAMPORTS_PER_SOL = 1000000000
 
-const TOTAL_CASES := 10
+const TOTAL_CASES := 11
 var passed_test_mask := 0
 
 
@@ -165,6 +165,27 @@ func transaction_with_confirmation_2():
 	PASS(9)
 
 
+func blockhash_before_instruction():
+	# Test that blockhash can be updated before adding instructions.
+	
+	var account_key: Keypair = Keypair.new_random()
+	var tx = Transaction.new()
+	
+	add_child(tx)
+	tx.set_payer(payer)
+
+	tx.update_latest_blockhash()
+
+	var ix: Instruction = SystemProgram.create_account(payer, account_key, LAMPORTS_PER_SOL / 10, 400, SystemProgram.get_pid())
+	tx.add_instruction(ix)
+
+	tx.sign_and_send()
+	var response = await tx.transaction_response_received
+	assert(response.has("result"))
+
+	PASS(10)
+
+
 func _ready():
 	# Use a local cluster for unlimited Solana airdrops.
 	# SolanaClient defaults to devnet cluster URL if not specified.
@@ -178,6 +199,7 @@ func _ready():
 	create_account_example()
 	transaction_with_confirmation_1()
 	transaction_with_confirmation_2()
+	blockhash_before_instruction()
 
 
 func _on_timeout_timeout():

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -416,8 +416,6 @@ bool Transaction::get_external_payer(){
 }
 
 void Transaction::update_latest_blockhash(const String &custom_hash){
-    ERR_FAIL_COND_EDMSG(instructions.size() == 0, "No instructions added to instruction.");
-    ERR_FAIL_COND_EDMSG(!is_message_valid(), "Failed to compile transaction message.");
     ERR_FAIL_COND_EDMSG(!is_inside_tree(), "Transaction node must be added to scene tree.");
 
     if(custom_hash.is_empty()){
@@ -513,7 +511,9 @@ void Transaction::blockhash_callback(Dictionary params){
         const Dictionary blockhash_result = params["result"];
         const Dictionary blockhash_value = blockhash_result["value"];
         latest_blockhash_string = blockhash_value["blockhash"];
-        Object::cast_to<Message>(message)->set_latest_blockhash(latest_blockhash_string);
+        if(is_message_valid()){
+            Object::cast_to<Message>(message)->set_latest_blockhash(latest_blockhash_string);
+        }
         emit_signal("blockhash_updated", params);
         Array connected_signals = get_signal_connection_list("send_ready");
         emit_signal("send_ready");


### PR DESCRIPTION
It was not possible to get blockhash before adding instructions. This can be desired in some situations. The prechecks were therefore removed from update_latest_blockhash method.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
