### PR TITLE
Fix mint CandyGuard crash on some guards

### DIFF
--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -93,14 +93,21 @@ CompiledInstruction::CompiledInstruction(){
 }
 
 int CompiledInstruction::create_from_bytes(const PackedByteArray& bytes){
+    const unsigned int MINIMUM_COMPILED_INSTRUCTION_SIZE = 3;
+    ERR_FAIL_COND_V_EDMSG(bytes.size() < MINIMUM_COMPILED_INSTRUCTION_SIZE, 0, "Invalid compiled instruction.");
+    
     int cursor = 0;
     program_id_index = bytes[cursor++];
 
     const unsigned int account_size = bytes[cursor++];
+
+    ERR_FAIL_COND_V_EDMSG(bytes.size() < MINIMUM_COMPILED_INSTRUCTION_SIZE + account_size, 0, "Invalid compiled instruction.");
     accounts = bytes.slice(cursor, cursor + account_size);
     cursor += account_size;
 
     const unsigned int data_size = bytes[cursor++];
+
+    ERR_FAIL_COND_V_EDMSG(bytes.size() < MINIMUM_COMPILED_INSTRUCTION_SIZE + account_size + data_size, 0, "Invalid compiled instruction.");
     data = bytes.slice(cursor, cursor + data_size);
     
     return cursor + data_size;

--- a/src/instructions/mpl_candy_machine.cpp
+++ b/src/instructions/mpl_candy_machine.cpp
@@ -1660,6 +1660,7 @@ Variant MplCandyGuard::mint(
     Instruction *result = memnew(Instruction);
 
     PackedByteArray data = MplCandyMachine::mint2_discriminator();
+
     data.append_array(Object::cast_to<CandyGuardAccessList>(candy_guard_acl)->get_group(label).serialize_mint_settings());
     data.append_array(serialize_label(label));
     
@@ -1721,7 +1722,7 @@ Variant MplCandyGuard::mint(
     TypedArray<AccountMeta> mint_arg_accounts = Object::cast_to<CandyGuardAccessList>(candy_guard_acl)->get_group(label).get_mint_arg_accounts(receiver);
     
     for(unsigned int i = 0; i < mint_arg_accounts.size(); i++){
-        result->append_meta(mint_arg_accounts[i]);
+        result->append_meta(*memnew(AccountMeta(mint_arg_accounts[i])));
     }
 
     return result;

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -310,6 +310,10 @@ Transaction::Transaction() {
 }
 
 Transaction::Transaction(const PackedByteArray& bytes){
+    const unsigned int MINIMUM_MESSAGE_SIZE = 32 + 4 + 1;
+    const unsigned int MINIMUM_TRANSACTION_SIZE = MINIMUM_MESSAGE_SIZE + 1;
+    ERR_FAIL_COND_EDMSG(bytes.size() < MINIMUM_TRANSACTION_SIZE, "Invalid transaction size");
+
     send_client = memnew(SolanaClient);
     blockhash_client = memnew(SolanaClient);
     subscribe_client = memnew(SolanaClient);
@@ -320,13 +324,16 @@ Transaction::Transaction(const PackedByteArray& bytes){
     subscribe_client->set_async_override(true);
 
     int cursor = 0;
+
     const unsigned int signer_size = bytes[cursor++];
+    ERR_FAIL_COND_EDMSG(bytes.size() < MINIMUM_MESSAGE_SIZE + 1 + signer_size * 64, "Invalid message size.");
     for(unsigned int i = 0; i < signer_size; i++){
         const PackedByteArray signature_bytes = bytes.slice(cursor, cursor + 64);
         if(! are_all_bytes_zeroes(signature_bytes)){
             ready_signature_amount += 1;
         }
         signatures.append(bytes.slice(cursor, cursor + 64));
+
         cursor += 64;
     }
 


### PR DESCRIPTION
When enabling some mint guards, the mint method crashes. This commit fixes the issue by allocating memory with memnew to comply with godot-cpp for godot 4.3.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
