### PR TITLE
Implement a way to copy metadata from a dictionary

### DIFF
--- a/include/meta_data/meta_data.hpp
+++ b/include/meta_data/meta_data.hpp
@@ -75,6 +75,19 @@ public:
     void set_collection(const Variant& collection);
     Variant get_collection();
 
+    /**
+     * @godot
+     * @brief Copies the existing data from a dictionary returned by the DAS methods
+     * 
+     * Checks the provided dictionary for metadata fields and copies them if they exist.
+     * If they do not exist the method will proceed without warnings.
+     * This method is meant to be used with dictionary format returned from DAS SolanaClient methods.
+     * 
+     * @param other Dictionary with data to copy. Must be compliant with the format returned from the
+     * DAS SolanaClient methods.
+     */
+    void copy_from_dict(const Dictionary &other);
+
     PackedByteArray serialize(const bool is_mutable) const;
 };
 }


### PR DESCRIPTION
Implement MetaData from_dict method. Copies elements from known paths into metadata properties. This is a useful method when fetching assets using DAS SolanaClient methods.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
