### PR TITLE
memcmp filters and filters for anchor types

### DIFF
--- a/include/anchor_program.hpp
+++ b/include/anchor_program.hpp
@@ -14,6 +14,7 @@ private:
     String pid;
     String url_override = "";
     String pending_account_name = "";
+    String pending_accounts_name = "";
     bool try_from_pid = false;
     Variant json_file;
     bool try_from_json_file = false;
@@ -31,6 +32,7 @@ private:
     bool load_from_pid(const String& pid);
     void idl_from_pid_callback(const Dictionary& rpc_result);
     void fetch_account_callback(const Dictionary &rpc_result);
+    void fetch_all_accounts_callback(const Dictionary &rpc_result);
     void extract_idl_from_rpc_response(const Dictionary& rpc_result);
     void extract_idl_from_data(const Array& data_info);
 
@@ -40,7 +42,8 @@ private:
     bool check_type(const Variant& expected_type, const Variant& value);
     bool validate_instruction_arguments(const String &instruction_name, const Array &arguments);
     void register_instruction_builders();
-    PackedByteArray discriminator_by_name(const String &name);
+    PackedByteArray discriminator_by_name(const String &name, const String &namespace_string);
+
     Dictionary find_idl_instruction(const String &name);
     Dictionary find_idl_account(const String &name);
     Dictionary find_idl_type(const String &name);
@@ -88,8 +91,13 @@ public:
     static Dictionary u64(uint64_t val);
     static Dictionary option(const Variant &val);
 
+
+    const String global_prefix = "global:";
+    const String account_prefix = "account:";
+
     Variant build_instruction(String name, Array accounts, Variant arguments);
     Error fetch_account(const String name, const Variant &account);
+    Error fetch_all_accounts(const String name, const Array& additional_filters = Array());
 };
 
 }

--- a/include/solana_client/solana_client.hpp
+++ b/include/solana_client/solana_client.hpp
@@ -61,7 +61,7 @@ private:
     void append_min_context_slot(Array& options);
     void append_encoding(Array& options);
     void append_account_filter(Array& options);
-    void append_data_filter(Array& options);
+    void append_data_filter(Array& options, const Array& filters);
     void append_transaction_detail(Array& options);
     void append_max_transaction_version(Array& options);
     void append_rewards(Array& options);
@@ -161,7 +161,7 @@ public:
     void get_max_shred_insert_slot();
     void get_minimum_balance_for_rent_extemption(uint64_t data_size);
     void get_multiple_accounts(const PackedStringArray accounts);
-    void get_program_accounts(const String& program_address, bool with_context = false);
+    void get_program_accounts(const String& program_address, const Array& filters = Array(), bool with_context = false);
     void get_recent_performance_samples();
     void get_recent_prioritization_fees(PackedStringArray account_addresses);
     void get_signature_for_address(const String& address, const String& before = "", const String& until = "");

--- a/include/solana_utils.hpp
+++ b/include/solana_utils.hpp
@@ -30,6 +30,9 @@ public:
     static String bs64_encode(PackedByteArray bytes);
     static PackedByteArray bs64_decode(String input);
 
+    static PackedByteArray short_u16_encode(unsigned int value);
+    static unsigned int short_u16_decode(const PackedByteArray &bytes, int *cursor);
+
     ~SolanaUtils();
 };
 }

--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -98,19 +98,19 @@ int CompiledInstruction::create_from_bytes(const PackedByteArray& bytes){
     
     int cursor = 0;
     program_id_index = bytes[cursor++];
-
-    const unsigned int account_size = bytes[cursor++];
-
-    ERR_FAIL_COND_V_EDMSG(bytes.size() < MINIMUM_COMPILED_INSTRUCTION_SIZE + account_size, 0, "Invalid compiled instruction.");
-    accounts = bytes.slice(cursor, cursor + account_size);
-    cursor += account_size;
-
-    const unsigned int data_size = bytes[cursor++];
-
-    ERR_FAIL_COND_V_EDMSG(bytes.size() < MINIMUM_COMPILED_INSTRUCTION_SIZE + account_size + data_size, 0, "Invalid compiled instruction.");
-    data = bytes.slice(cursor, cursor + data_size);
     
-    return cursor + data_size;
+    const unsigned int accounts_len = SolanaUtils::short_u16_decode(bytes, &cursor);
+
+    ERR_FAIL_COND_V_EDMSG(bytes.size() < MINIMUM_COMPILED_INSTRUCTION_SIZE + accounts_len, 0, "Invalid compiled instruction.");
+    accounts = bytes.slice(cursor, cursor + accounts_len);
+    cursor += accounts_len;
+
+    const unsigned int data_len = SolanaUtils::short_u16_decode(bytes, &cursor);
+
+    ERR_FAIL_COND_V_EDMSG(bytes.size() < MINIMUM_COMPILED_INSTRUCTION_SIZE + accounts_len + data_len, 0, "Invalid compiled instruction.");
+    data = bytes.slice(cursor, cursor + data_len);
+    
+    return cursor + data_len;
 }
 
 void CompiledInstruction::_bind_methods(){
@@ -120,14 +120,15 @@ PackedByteArray CompiledInstruction::serialize(){
     PackedByteArray result;
 
     result.append(program_id_index);
-    result.append(accounts.size());
+    result.append_array(SolanaUtils::short_u16_encode(accounts.size()));
 
     for(unsigned int i = 0; i < accounts.size(); i++){
         result.append(accounts[i]);
     }
 
 
-    result.append(data.size());
+    
+    result.append_array(SolanaUtils::short_u16_encode(data.size()));
     for(unsigned int i = 0; i < data.size(); i++){
         result.append(data[i]);
     }

--- a/src/solana_client/solana_client.cpp
+++ b/src/solana_client/solana_client.cpp
@@ -116,7 +116,10 @@ void SolanaClient::append_account_filter(Array& options){
     }
 }
 
-void SolanaClient::append_data_filter(Array& options){
+void SolanaClient::append_data_filter(Array& options, const Array& filters){
+    if(!filters.is_empty()){
+        add_to_param_dict(options, "filters", filters);
+    }
     
 }
 
@@ -186,7 +189,6 @@ void SolanaClient::quick_http_request(const Dictionary& request_body, const Call
 
     Dictionary parsed_url = parse_url(get_real_url());
     const uint32_t real_port = get_real_http_port();
-
     // Check if port is set in URL.
     if(parsed_url.has("port")){
         if(real_port != (uint32_t)parsed_url["port"]){
@@ -421,7 +423,7 @@ void SolanaClient::get_multiple_accounts(const PackedStringArray accounts){
     return quick_http_request(make_rpc_dict("getMultipleAccounts", params));
 }
 
-void SolanaClient::get_program_accounts(const String& program_address, bool with_context){
+void SolanaClient::get_program_accounts(const String& program_address, const Array& filters, bool with_context){
     Array params;
     params.append(program_address);
     append_commitment(params);
@@ -429,8 +431,7 @@ void SolanaClient::get_program_accounts(const String& program_address, bool with
     add_to_param_dict(params, "withContext", with_context);
     append_encoding(params);
     append_account_filter(params);
-    append_data_filter(params);
-
+    append_data_filter(params, filters);
     return quick_http_request(make_rpc_dict("getProgramAccounts", params));
 }
 
@@ -810,7 +811,7 @@ void SolanaClient::_bind_methods(){
     ClassDB::bind_method(D_METHOD("get_max_shred_insert_slot"), &SolanaClient::get_max_shred_insert_slot);
     ClassDB::bind_method(D_METHOD("get_minimum_balance_for_rent_extemption", "data_size"), &SolanaClient::get_minimum_balance_for_rent_extemption);
     ClassDB::bind_method(D_METHOD("get_multiple_accounts", "accounts"), &SolanaClient::get_multiple_accounts);
-    ClassDB::bind_method(D_METHOD("get_program_accounts", "program_address", "with_context"), &SolanaClient::get_program_accounts);
+    ClassDB::bind_method(D_METHOD("get_program_accounts", "program_address", "filters", "with_context"), &SolanaClient::get_program_accounts, DEFVAL(Array()), DEFVAL(false));
     ClassDB::bind_method(D_METHOD("get_recent_performance_samples"), &SolanaClient::get_recent_performance_samples);
     ClassDB::bind_method(D_METHOD("get_recent_prioritization_fees", "account_addresses"), &SolanaClient::get_recent_prioritization_fees);
     ClassDB::bind_method(D_METHOD("get_signature_for_address", "address", "before", "until"), &SolanaClient::get_signature_for_address);

--- a/src/solana_utils.cpp
+++ b/src/solana_utils.cpp
@@ -211,5 +211,36 @@ PackedByteArray SolanaUtils::bs64_decode(String input){
 	return result.slice(0, result.size() - cutoff);
 }
 
+PackedByteArray SolanaUtils::short_u16_encode(const unsigned int value) {
+    PackedByteArray result;
+    unsigned int remaining = value;
+    for (int i = 0; i < 3; ++i) {
+        uint8_t byte = remaining & 0x7f;
+        remaining >>= 7;
+        if (remaining == 0) {
+            result.append(byte);
+            break;
+        } else {
+            byte |= 0x80;
+            result.append(byte);
+        }
+    }
+    return result;
+}
+
+unsigned int SolanaUtils::short_u16_decode(const PackedByteArray& bytes, int* cursor) {
+    unsigned int value = 0;
+    int initial_cursor = *cursor;
+    for (int i = 0; i < 3 && (*cursor) < bytes.size(); ++i) {
+        uint8_t byte = bytes[*cursor];
+        value |= static_cast<unsigned int>(byte & 0x7f) << (7 * i);
+        (*cursor)++;
+        if ((byte & 0x80) == 0) {
+            break;
+        }
+    }
+    return value;
+}
+
 SolanaUtils::~SolanaUtils() {
 }


### PR DESCRIPTION
short_u16 fix on instruction

* **Please check if the PR fulfills these requirements**
- [ x] The commit(s) are rebased and squashed
- [ 🥸] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds a way to fetch accounts with an rpc filter struct

* **What is the current behavior?** (You can also link to an open issue here)
get_program_accounts does not accept filters, so GPA cannot be used for e.g. memcmp filters

* **What is the new behavior (if this is a feature change)?**
get_program_accounts optionally accepts filters, anchor programs can also now use this to create typed/positional filters. Later they can be named by stacking into an offsets dict, but for now they are 

* **Other information**:
also made short_u16_encode and short_u16_decode and use it for instruction data because it was an issue when trying the changes. This could help create a shortvec or be used by default for the shortvec cases (there are only a few)