### PR TITLE
Added serializing optional accounts to instruction building

### DIFF
--- a/include/anchor_program.hpp
+++ b/include/anchor_program.hpp
@@ -25,6 +25,7 @@ private:
 
     bool detect_writable(const Dictionary& account);
     bool detect_is_signer(const Dictionary& account);
+    bool detect_optional(const Dictionary& account);
 
     static bool is_typed_primitive(const Dictionary &dict);
     static PackedByteArray serialize_typed_primitive(const Dictionary &dict);


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit(s) are rebased and squashed
- [x] Commits are concise and does not contain several different changes.
- [x] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It adds support for the Optional accounts feature to the Anchor program client. #284 

* **What is the current behavior?** (You can also link to an open issue here)
Not implemented

* **What is the new behavior (if this is a feature change)?**
Implemented

* **Other information**:
