### PR TITLE
Hide callback internal functions from Godot

### DIFF
--- a/include/transaction/transaction.hpp
+++ b/include/transaction/transaction.hpp
@@ -11,6 +11,12 @@
 
 namespace godot{
 
+enum ConfirmationLevel{
+    CONFIRMED,
+    PROCESSED,
+    FINALIZED,
+};
+
 class Transaction : public Node {
     GDCLASS(Transaction, Node)
 
@@ -62,7 +68,7 @@ private:
 
     void sign_at_index(const uint32_t index);
     void copy_connection_state();
-    void subscribe_to_signature(const String& confirmation_level);
+    void subscribe_to_signature(ConfirmationLevel confirmation_level);
     void subscribe_to_signature();
 
     void _emit_processed_callback(const Dictionary &params);
@@ -112,7 +118,6 @@ public:
     PackedByteArray serialize_signers();
     Error sign();
     void send();
-    void send_and_disconnect();
     Variant sign_and_send();
     Error partially_sign(const Variant& latest_blockhash);
 


### PR DESCRIPTION
The callback methods are bound to ClassDB to enable connecting them to signals. These methods are removed by connecting the callbacks with the callable_mp macro. The macro allows c++ methods to be connected.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
