### PR TITLE
Add check for polling multiple times per frame

### DIFF
--- a/example/SolanaClient/solana_client_examples.tscn
+++ b/example/SolanaClient/solana_client_examples.tscn
@@ -28,7 +28,7 @@ size_flags_vertical = 3
 columns = 2
 
 [node name="Timeout" type="Timer" parent="."]
-wait_time = 20.0
+wait_time = 50.0
 one_shot = true
 autostart = true
 

--- a/include/solana_client/rpc_multi_http_request_client.hpp
+++ b/include/solana_client/rpc_multi_http_request_client.hpp
@@ -16,6 +16,7 @@ private:
     TypedArray<RpcSingleHttpRequestClient> requests;
 
 protected:
+    unsigned int last_processed_frame = 0;
     bool pending_request = false;
 
     static void _bind_methods();

--- a/include/solana_client/rpc_single_http_request_client.hpp
+++ b/include/solana_client/rpc_single_http_request_client.hpp
@@ -19,6 +19,8 @@ typedef struct{
 class RpcSingleHttpRequestClient : public HTTPClient{
     GDCLASS(RpcSingleHttpRequestClient, HTTPClient)
 private:
+    bool skip_id = false;
+
     std::queue<RequestData> request_queue;
     PackedByteArray response_data;
 
@@ -37,6 +39,7 @@ protected:
     static void _bind_methods();
 public:
     bool is_completed() const;
+    void set_skip_id(bool skip_id);
 
     void process(const float delta);
     void asynchronous_request(const Dictionary& request_body, Dictionary parsed_url, const Callable &callback, float timeout = 20.0F);

--- a/include/solana_client/rpc_single_ws_request_client.hpp
+++ b/include/solana_client/rpc_single_ws_request_client.hpp
@@ -29,6 +29,7 @@ class RpcSingleWsRequestClient : public WebSocketPeer{
     GDCLASS(RpcSingleWsRequestClient, WebSocketPeer)
 private:
     bool connecting = false;
+    unsigned int last_processed_frame = 0;
 
     std::deque<WsRequestData> request_queue;
     std::vector<SubscriptionData> subscriptions;

--- a/include/solana_client/solana_client.hpp
+++ b/include/solana_client/solana_client.hpp
@@ -47,6 +47,7 @@ private:
     bool slot_range_enabled = false;
 
     Callable ws_callback;
+    Callable rpc_callback = Callable(this, "response_callback");
 
     String ws_from_http(const String& http_url);
     String get_real_url();
@@ -73,7 +74,6 @@ private:
 
     Dictionary make_rpc_param(const Variant& key, const Variant& value);
     void quick_http_request(const Dictionary& request_body, const Callable& callback = Callable());
-    Dictionary parse_url(const String& url);
 
     void response_callback(const Dictionary &params);
     void ws_response_callback(const Dictionary &params);
@@ -82,6 +82,7 @@ protected:
     static void _bind_methods();
 
 public:
+    static Dictionary parse_url(const String& url);
     static String assemble_url(const Dictionary& url_components);
 
     static unsigned int global_rpc_id;
@@ -93,6 +94,8 @@ public:
     static Dictionary make_rpc_dict(const String& method, const Array& params);
 
     SolanaClient();
+
+    void set_callback(Callable callback);
 
     void set_url_override(const String& url);
     String get_url_override();

--- a/src/solana_client/rpc_multi_http_request_client.cpp
+++ b/src/solana_client/rpc_multi_http_request_client.cpp
@@ -1,4 +1,5 @@
 #include "rpc_multi_http_request_client.hpp"
+#include <godot_cpp/classes/engine.hpp>
 
 namespace godot{
 
@@ -6,6 +7,12 @@ void RpcMultiHttpRequestClient::_bind_methods(){
 }
 
 void RpcMultiHttpRequestClient::process(float delta){
+    unsigned int current_frame = Engine::get_singleton()->get_process_frames();
+    if(current_frame == last_processed_frame){
+        return;
+    }
+    last_processed_frame = current_frame;
+
     for(unsigned int i = 0; i < requests.size(); i++){
         RpcSingleHttpRequestClient *single_client = Object::cast_to<RpcSingleHttpRequestClient>(requests[i]);
         single_client->process(delta);

--- a/src/solana_client/rpc_single_http_request_client.cpp
+++ b/src/solana_client/rpc_single_http_request_client.cpp
@@ -31,7 +31,15 @@ bool RpcSingleHttpRequestClient::is_completed() const{
     return !is_pending() && !has_request();
 }
 
+void RpcSingleHttpRequestClient::set_skip_id(bool skip_id){
+    this->skip_id = skip_id;
+}
+
 bool RpcSingleHttpRequestClient::is_response_valid(const Dictionary& response) const{
+    if(skip_id){
+        return true;
+    }
+    
     // Check if response is ours.
     if(!response.has("id")){
         return false;
@@ -181,7 +189,14 @@ void RpcSingleHttpRequestClient::_bind_methods(){
 }
 
 void RpcSingleHttpRequestClient::asynchronous_request(const Dictionary& request_body, Dictionary parsed_url, const Callable &callback, float timeout){
-    RequestData data = {request_body, parsed_url, timeout, request_body["id"], callback};
+    RequestData data;
+    if(skip_id){
+        data = {request_body, parsed_url, timeout, 0, callback};
+    }
+    else{
+        data = {request_body, parsed_url, timeout, request_body["id"], callback};
+    }
+
     request_queue.push(data);
 }
 

--- a/src/solana_client/rpc_single_ws_request_client.cpp
+++ b/src/solana_client/rpc_single_ws_request_client.cpp
@@ -2,6 +2,7 @@
 
 #include <godot_cpp/classes/json.hpp>
 #include <solana_client.hpp>
+#include <godot_cpp/classes/engine.hpp>
 
 namespace godot{
 
@@ -16,6 +17,12 @@ bool RpcSingleWsRequestClient::is_pending(){
 }
 
 void RpcSingleWsRequestClient::process(float delta){
+    unsigned int current_frame = Engine::get_singleton()->get_process_frames();
+    if(current_frame == last_processed_frame){
+        return;
+    }
+    last_processed_frame = current_frame;
+
     WebSocketPeer::poll();
     WebSocketPeer::State state = get_ready_state();
     switch(state){

--- a/src/solana_client/solana_client.cpp
+++ b/src/solana_client/solana_client.cpp
@@ -200,7 +200,7 @@ void SolanaClient::quick_http_request(const Dictionary& request_body, const Call
     }
 
     if(is_inside_tree() || async_override){
-        get_current_http_client()->asynchronous_request(request_body, parsed_url, Callable(this, "response_callback"));
+        get_current_http_client()->asynchronous_request(request_body, parsed_url, rpc_callback);
     }
     else{
         ERR_FAIL_EDMSG("SolanaClient must be in scene tree.");
@@ -819,6 +819,7 @@ void SolanaClient::_bind_methods(){
     ClassDB::add_signal("SolanaClient", MethodInfo("http_response_received", PropertyInfo(Variant::DICTIONARY, "response")));
 
     ClassDB::bind_static_method("SolanaClient", D_METHOD("assemble_url", "url"), &SolanaClient::assemble_url);
+    ClassDB::bind_static_method("SolanaClient", D_METHOD("parse_url", "url"), &SolanaClient::parse_url);
     ClassDB::bind_static_method("SolanaClient", D_METHOD("get_next_request_identifier"), &SolanaClient::get_next_request_identifier);
 
     ClassDB::bind_method(D_METHOD("response_callback", "params"), &SolanaClient::response_callback);
@@ -826,8 +827,6 @@ void SolanaClient::_bind_methods(){
     ClassDB::bind_method(D_METHOD("set_url_override", "url_override"), &SolanaClient::set_url_override);
     ClassDB::bind_method(D_METHOD("get_url_override"), &SolanaClient::get_url_override);
     ClassDB::bind_method(D_METHOD("is_ready"), &SolanaClient::is_ready);
-
-    ClassDB::bind_method(D_METHOD("parse_url", "url"), &SolanaClient::parse_url);
 
     ClassDB::bind_method(D_METHOD("set_ws_url", "url"), &SolanaClient::set_ws_url);
     ClassDB::bind_method(D_METHOD("get_ws_url"), &SolanaClient::get_ws_url);
@@ -1065,6 +1064,10 @@ void SolanaClient::set_ws_url(const String& url){
 
 String SolanaClient::get_ws_url(){
     return ws_url;
+}
+
+void SolanaClient::set_callback(Callable callback){
+    rpc_callback = callback;
 }
 
 String SolanaClient::get_url_override(){


### PR DESCRIPTION
The SolanaClients were polling multiple times per frame. This also caused timeouts to speed up. This commit adds a check to only poll once per frame. It also somewhat fixes the timeout sync. It can still be inaccurate due to differences in the polling instance delta value.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
