### PR TITLE
Add in editor documentation from doxygen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ test-ledger/
 .vscode/
 .godot/
 
+__pycache__/
+*.pyc
+
 # Doxygen
 docs/html/
 docs/xml/

--- a/SConstruct
+++ b/SConstruct
@@ -2,12 +2,21 @@
 
 import os
 import platform
+from docs.xml_to_header import doxy_to_header, get_classes_list
 
 CONTAINER_BUILD_PATH = "build-containers"
 CONTAINER_NAME = "godot-solana-sdk-container"
 LIBRARY_NAME = "godot-solana-sdk"
 IPHONE_SDK_VERSION = 17.0
 IOS_OSXCROSS_TRIPPLE = 23
+
+DOC_HEADER_NAME = "include/doc_data_godot-solana-sdk.gen.h"
+
+
+def build_docs(env):
+    class_list = get_classes_list("docs/xml")
+    doxy_to_header(class_list, DOC_HEADER_NAME)
+
 
 def set_tmp_dir(platform, target):
     dir_name = f".godot/build_files/{platform}/{target}/"
@@ -155,6 +164,8 @@ if env.GetOption('container_build'):
     exit(0)
 
 else:
+
+    build_docs(env)
 
     set_tmp_dir(env["platform"], env["target"])
     if env["platform"] == "ios" and platform.system() != "Darwin":

--- a/docs/xml_to_header.py
+++ b/docs/xml_to_header.py
@@ -1,0 +1,229 @@
+import xml.etree.ElementTree as ET
+import re
+import os
+
+
+# Godot does not handle \t in docs
+TAB = "        "
+
+DOC_HEADER_NAME = "include/doc_data_godot-solana-sdk.gen.h"
+
+
+def add_refs_to_description(text):
+    TYPES_TO_REF = [
+        "Pubkey",
+        "Variant",
+        "Resource"
+    ]
+    for ref in TYPES_TO_REF:
+        text = text.replace(f' {ref}', f' [{ref}]')
+
+    return text
+
+
+def build_xml_func(method):
+    root = ET.Element("method", name = method["name"])
+    if "deprecated" in method:
+        root.set("deprecated", method["deprecated"])
+    ET.SubElement(root, "return", type = method["return"])
+    for idx, param in enumerate(method["params"]):
+        ET.SubElement(root, "param", index=str(idx), name=param["name"], type=param["type"])
+
+    description_element = ET.SubElement(root, "description")
+
+    splits = method["detailed"].split("\n", 1)
+    args = re.sub(r'(\n)+', r'\n', splits[1]).lstrip().rstrip().split("\n")
+    arg_description = ""
+    for i in range(0, len(args)-1, 2):
+        arg_description += f'{TAB}[i]{args[i]}[/i]: {args[i+1]}\n'
+    
+    if len(args) % 2:
+        if args[-1] == '':
+            arg_description += f'{TAB}[i]return[/i]: {splits[0]}'
+        else:
+            arg_description += f'{TAB}[i]return[/i]: {args[-1]}'
+
+    brief = method["brief"].rstrip()
+    desctiption_text = re.sub(r'(\n)+', r'\n', f'{brief}\n{splits[0]}\n{arg_description}')
+    
+    description_element.text = add_refs_to_description(desctiption_text)
+
+    return root
+
+
+def build_xml(data):
+    root = ET.Element("class", name = data["class_name"])
+    brief = ET.SubElement(root, "brief_description")
+    brief.text = data["brief"]
+    detailed = ET.SubElement(root, "description")
+    detailed.text = data["detailed"]
+
+    method_element = ET.SubElement(root, "methods")
+
+    for method in data["methods"]:
+        method_child = build_xml_func(method)
+        method_element.append(method_child)
+
+    return ET.tostring(root, encoding='unicode', method='xml')
+
+
+def tree_to_text(tree):
+    result = ""
+    for child in tree:
+        if child.tag == "para":
+            result += ET.tostring(child, encoding='unicode', method='text')
+
+    return result
+
+
+def get_param_type(tree):
+    if tree.find("ref"):
+        return "Variant"
+    return tree.text.replace("const", "").replace("&", "").lstrip().rstrip()
+
+
+def tree_to_func(tree):
+    GODOT_ACCESSIBLE = "Godot Accessible!\n \n"
+
+    result = {}
+
+    return_type = tree.find("type")
+    result["return"] = return_type.text
+    function_name = tree.find("name")
+    result["name"] = function_name.text
+
+    # params
+    param_list = []
+    params = tree.findall(".//param")
+    for param in params:
+        param_info = {}
+        param_type = param.find("type")
+        param_info["type"] = get_param_type(param_type)
+        param_name = param.find("declname")
+        param_info["name"] = param_name.text
+
+        param_list.append(param_info)
+
+    result["params"] = param_list
+
+    brief = tree.find("briefdescription")
+    if brief:
+        result["brief"] = tree_to_text(brief)
+
+    detailed = tree.find("detaileddescription")
+
+
+    for child in detailed:
+        simplesect = child.find('simplesect')
+        if simplesect is not None:
+            if simplesect.get("kind") == "note":
+                result["note"] = simplesect.find("para").text
+                child.remove(simplesect)
+
+        xreftitles = child.findall('.//xreftitle')
+        for xreftitle in xreftitles:
+            if xreftitle.text == "Deprecated":
+                descriptions = child.findall('.//xrefdescription')
+                if not descriptions:
+                    continue
+
+                result["deprecated"] = descriptions[0].find("para").text
+                child.remove(child.find("xrefsect"))
+
+
+    if detailed:
+        result["detailed"] = tree_to_text(detailed)
+        if result["detailed"].find(GODOT_ACCESSIBLE) > -1:
+            result["detailed"] = result["detailed"].replace(GODOT_ACCESSIBLE, '')
+            result["godot"] = True
+        else:
+            result["godot"] = False
+    return result
+
+
+def parse_doxy_class(source):
+    data = ET.parse(source)
+    root = data.getroot()
+    result = {}
+
+    class_name = root.findall(".//compoundname")
+    result["class_name"] = class_name[0].text.split("::")[-1]
+
+    doc_class = root.findall('.//compounddef')
+    class_description = doc_class[0].find('briefdescription')
+    result["brief"] = tree_to_text(class_description)
+    class_detailed = doc_class[0].find('detaileddescription')
+
+    result["detailed"] = tree_to_text(class_detailed)
+    
+    memberdefs = doc_class[0].findall('.//memberdef')
+
+    godot_funcs = []
+
+    for memberdef in memberdefs:
+        member_type = memberdef.get("kind")
+
+        if(member_type == "function"):
+            parsed_func = tree_to_func(memberdef)
+
+            if not "godot" in parsed_func:
+                continue
+            if parsed_func["godot"]:
+                godot_funcs.append(parsed_func)
+
+    result["methods"] = godot_funcs
+
+    if len(godot_funcs) == 0:
+        return ""
+    else:
+        return build_xml(result)
+
+
+def doxy_to_header(sources, target):
+    xml_string = ""
+    for source in sources:
+        xml_string += parse_doxy_class(source)
+
+    make_doc_header(target, xml_string)
+
+
+def make_doc_header(target, raw_data):
+    dst = str(target)
+    g = open(dst, "w", encoding="utf-8")
+
+    g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
+    g.write("#ifndef _DOC_DATA_RAW_H\n")
+    g.write("#define _DOC_DATA_RAW_H\n")
+
+    g.write("static const int _doc_data_size = " + str(len(raw_data)) + ";\n")
+    g.write("static const char _doc_data[] = {\n")
+    for i in range(len(raw_data)):
+        g.write("\t" + str(ord(raw_data[i])) + ",\n")
+    g.write("};\n")
+
+    g.write("#endif")
+
+    g.close()
+
+def get_classes_list(folder_path):
+    PREFIX = "classgodot_1_1_"
+    class_list = []
+
+    try:
+        with os.scandir(folder_path) as entries:
+            for entry in entries:
+                # Check if the entry is a file and if its name starts with the prefix
+                if entry.is_file() and entry.name.startswith(PREFIX):
+                    class_list.append(os.path.join(folder_path, entry.name))
+
+    except FileNotFoundError:
+        print("The specified folder path does not exist.")
+    except Exception as e:
+        print(f"An error occurred: {e}")
+    
+    return class_list
+
+
+class_list = get_classes_list("docs/xml")
+doxy_to_header(class_list, DOC_HEADER_NAME)
+#doxy_to_header(["docs/xml/classgodot_1_1_pubkey.xml"], DOC_HEADER_NAME)

--- a/include/hash.hpp
+++ b/include/hash.hpp
@@ -6,6 +6,7 @@
 
 
 namespace godot{
+
 class Hash : public Resource {
     GDCLASS(Hash, Resource)
 

--- a/include/pubkey.hpp
+++ b/include/pubkey.hpp
@@ -73,6 +73,7 @@ public:
     Pubkey(const Variant& from);
 
     /**
+     * @godot
      * @brief Configure Pubkey from base58 encoded string.
      * 
      * Decodes p_value into 32 bytes key and configures the Pubkey properties.
@@ -83,6 +84,7 @@ public:
     void from_string(const String& p_value);
 
     /**
+     * @godot
      * @brief Returns the base58 encoded key.
      * 
      * @return Base58 encoded key.
@@ -90,6 +92,7 @@ public:
     String to_string() const;
 
     /**
+     * @godot
      * @brief Sets an unused seed property.
      * 
      * @deprecated Try either new_from_bytes or new_from_seed instead.
@@ -99,6 +102,7 @@ public:
     void set_seed(const String& p_value);
 
     /**
+     * @godot
      * @brief Gets an unused seed property.
      * 
      * @deprecated Seed is not used.
@@ -108,6 +112,7 @@ public:
     String get_seed();
 
     /**
+     * @godot
      * @brief Configure Pubkey from 32 byte array.
      * 
      * Configures the Pubkey properties from a 32 byte array.
@@ -118,6 +123,7 @@ public:
     void from_bytes(const PackedByteArray& p_value);
 
     /**
+     * @godot
      * @brief Returns the 32 byte key array.
      * 
      * @return The 32 byte key array.
@@ -125,6 +131,7 @@ public:
     PackedByteArray to_bytes() const;
 
     /**
+     * @godot
      * @brief Set type of Pubkey.
      * 
      * @deprecated Type is not used anything.
@@ -134,6 +141,7 @@ public:
     void set_type(const String p_value);
 
     /**
+     * @godot
      * @brief Gets Pubkey type.
      * 
      * @deprecated Type is not used anything.
@@ -143,6 +151,7 @@ public:
     String get_type() const;
 
     /**
+     * @godot
      * @brief Set base of Pubkey.
      * 
      * Used when creating Pubkeys from seeds.
@@ -154,6 +163,7 @@ public:
     void set_base(const Variant p_value);
 
     /**
+     * @godot
      * @brief Get base property of Pubkey.
      * 
      * Gets the base used when creating Pubkeys from seeds.
@@ -165,6 +175,7 @@ public:
     Variant get_base();
 
     /**
+     * @godot
      * @brief Set owner of Pubkey.
      * 
      * Sets owner when generating the pubkey from seed.
@@ -176,6 +187,7 @@ public:
     void set_owner(const Variant p_value);
 
     /**
+     * @godot
      * @brief Gets the owner of the Pubkey.
      * 
      * Gets the owner used when generating pubkey from seed.
@@ -187,6 +199,7 @@ public:
     Variant get_owner();
 
     /**
+     * @godot
      * @brief Set the wallet address object.
      * 
      * Sets the wallet address used when generating an associated token address.
@@ -198,6 +211,7 @@ public:
     void set_wallet_address(const Variant p_value);
 
     /**
+     * @godot
      * @brief Get the wallet address object
      * 
      * Gets the wallet address used when derriving associated token address.
@@ -209,6 +223,7 @@ public:
     Variant get_wallet_address();
 
     /**
+     * @godot
      * @brief Set the token mint address object
      * 
      * Sets the token mint address used when generating associated token accounts.
@@ -220,6 +235,7 @@ public:
     void set_token_mint_address(const Variant p_value);
 
     /**
+     * @godot
      * @brief Get the token mint address object
      * 
      * Gets the token mint address used when generating associated token accounts.
@@ -231,6 +247,7 @@ public:
     Variant get_token_mint_address();
 
     /**
+     * @godot
      * @brief Constructs this Pubkey resource from string object.
      * 
      * Takes a base58 encoded string and constructs this Pubkey resource from it.
@@ -332,6 +349,7 @@ public:
      */
     static Variant new_pda_bytes(const Array seeds, const Variant &program_id);
     /**
+     * @godot
      * @brief Creates a new random Pubkey resource.
      * 
      * Creates a new random Pubkey by filling each byte randomly.
@@ -368,6 +386,7 @@ public:
     static String string_from_variant(const Variant& other);
 
     /**
+     * @godot
      * @brief Constructs a program address object
      * 
      * Constructs this Pubkey into a program derived address.
@@ -390,6 +409,7 @@ public:
      */
     bool create_program_address_bytes(const Array seeds, const Variant &program_id);
     /**
+     * @godot
      * @brief Constructs an associated token address.
      * 
      * Takes a wallet address and token mint address to get an associated token account.

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -66,7 +66,7 @@ void Pubkey::_bind_methods() {
     ClassDB::bind_static_method("Pubkey", D_METHOD("new_random"), &Pubkey::new_random);
 
     ClassDB::bind_method(D_METHOD("to_string"), &Pubkey::to_string);
-    ClassDB::bind_method(D_METHOD("set_string", "p_value"), &Pubkey::from_string);
+    ClassDB::bind_method(D_METHOD("from_string", "p_value"), &Pubkey::from_string);
     ClassDB::bind_method(D_METHOD("to_bytes"), &Pubkey::to_bytes);
     ClassDB::bind_method(D_METHOD("from_bytes", "p_value"), &Pubkey::from_bytes);
     ClassDB::bind_method(D_METHOD("get_seed"), &Pubkey::get_seed);

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -38,6 +38,9 @@
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/engine.hpp>
 
+#include "doc_data_godot-solana-sdk.gen.h"
+
+
 using namespace godot;
 
 void add_setting(const String& name, Variant::Type type, Variant default_value, PropertyHint hint = PropertyHint::PROPERTY_HINT_NONE, const String& hint_string = ""){
@@ -58,6 +61,10 @@ void add_setting(const String& name, Variant::Type type, Variant default_value, 
 }
 
 void initialize_solana_sdk_module(ModuleInitializationLevel p_level) {
+    if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8CharsAndLen editor_help_load_xml_from_utf8_chars_and_len = (GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8CharsAndLen)internal::gdextension_interface_get_proc_address("editor_help_load_xml_from_utf8_chars_and_len");
+        editor_help_load_xml_from_utf8_chars_and_len(_doc_data, _doc_data_size);
+	}
     if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
         return;
     }
@@ -118,6 +125,7 @@ void uninitialize_solana_sdk_module(ModuleInitializationLevel p_level) {
 extern "C" {
 // Initialization.
 GDExtensionBool GDE_EXPORT solana_sdk_library_init(const GDExtensionInterfaceGetProcAddress interface, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
+
     godot::GDExtensionBinding::InitObject init_obj(interface, p_library, r_initialization);
 
     init_obj.register_initializer(initialize_solana_sdk_module);


### PR DESCRIPTION
Currently there is no in editor documentation and users have no quick way to find information. This commit adds in editor documentation by extending the build script with another python script. This python script takes generated doxygen XML files and generates a header file. The class register code is extended to add the documentation in that header file.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
