### PR TITLE
Fix signature verification failure for web wallets

### DIFF
--- a/example/WalletAdapterWeb/WalletAdapterWeb.tscn
+++ b/example/WalletAdapterWeb/WalletAdapterWeb.tscn
@@ -32,7 +32,7 @@ text = "Signature: "
 autowrap_mode = 1
 
 [node name="Timeout" type="Timer" parent="."]
-wait_time = 5.0
+wait_time = 10.0
 one_shot = true
 autostart = true
 

--- a/example/WalletAdapterWeb/project.godot
+++ b/example/WalletAdapterWeb/project.godot
@@ -22,6 +22,6 @@ renderer/rendering_method.mobile="gl_compatibility"
 
 [solana_sdk]
 
-client/default_url="http://127.0.0.1"
 client/default_http_port=8899
 client/default_ws_port=8900
+client/default_url="http://127.0.0.1"

--- a/include/transaction/merged_account_metas.hpp
+++ b/include/transaction/merged_account_metas.hpp
@@ -19,6 +19,11 @@ public:
 	MergedAccountMetas() = default;
 
 	/**
+	 * @brief Resets the account meta list.
+	 */
+	void clear();
+
+	/**
 	 * @brief Adds an account meta into merged list.
 	 *
 	 * This method adds a new entry to its merged account meta list if address is

--- a/include/transaction/transaction.hpp
+++ b/include/transaction/transaction.hpp
@@ -83,7 +83,7 @@ protected:
 
 public:
 	Transaction() = default;
-	Transaction(const PackedByteArray &bytes);
+	void from_bytes(const PackedByteArray &bytes);
 
 	static Variant new_from_bytes(const PackedByteArray &bytes);
 

--- a/include/wallet_adapter/script_builder.hpp
+++ b/include/wallet_adapter/script_builder.hpp
@@ -30,8 +30,11 @@ const char *SIGN_TRANSACTION_SCRIPT = "\
   async function storeTransactionSignature() {\
     \
     try{\
+      Module.old_serialized_message = new Uint8Array(Module.serialized_message);\
       var tx = Module.Transaction.from(Module.serialized_message);\
       var response = (await Module.wallet_handler.signTransaction(tx));\
+      Module.tampered_serialized_message = response.serialize();\
+      console.log(response);\
       Module.message_signature = response.signatures[{0}].signature;\
       if(Module.message_signature == null){\
         Module.wallet_status = -1;\

--- a/include/wallet_adapter/wallet_adapter.hpp
+++ b/include/wallet_adapter/wallet_adapter.hpp
@@ -52,6 +52,7 @@ class WalletAdapter : public Node {
 	GDCLASS(WalletAdapter, Node)
 private:
 	bool connected = false;
+	bool dirty_transaction = false;
 	uint32_t active_signer_index = 0;
 	enum State {
 		IDLE = 0,
@@ -73,6 +74,8 @@ private:
 	static String get_sign_message_script();
 	String get_connect_script() const;
 	static bool is_wallet_installed(WalletType wallet_type);
+	static bool is_message_tampered(const PackedByteArray &original_serialization, const PackedByteArray &new_serialization);
+	static PackedByteArray strip_signatures(const PackedByteArray &serialization);
 	static Array get_all_wallets();
 
 protected:
@@ -88,12 +91,14 @@ public:
 
 	bool is_connected() const;
 	bool is_idle();
+	bool did_transaction_change() const;
 	static bool has_multiple_wallets();
 
 	void poll_connection();
 	void poll_message_signing();
 	Variant get_connected_key();
 	static PackedByteArray get_message_signature();
+	static PackedByteArray get_modified_transaction();
 
 	static Array get_available_wallets();
 

--- a/src/transaction/merged_account_metas.cpp
+++ b/src/transaction/merged_account_metas.cpp
@@ -40,6 +40,10 @@ void MergedAccountMetas::merge_at(const AccountMeta *account_meta, int64_t index
 	existing_meta->set_writeable(existing_meta->get_writeable() || account_meta->get_writeable());
 }
 
+void MergedAccountMetas::clear() {
+	merged_metas.clear();
+}
+
 void MergedAccountMetas::add(const Variant &account_meta) {
 	const auto *account_meta_ptr = Object::cast_to<AccountMeta>(account_meta);
 	const int64_t index = find(*account_meta_ptr);

--- a/src/transaction/message.cpp
+++ b/src/transaction/message.cpp
@@ -90,6 +90,9 @@ void Message::create(const MergedAccountMetas &merged_meta_list, Variant &payer)
 
 void Message::create(const PackedByteArray &bytes) {
 	int64_t cursor = 0;
+	compiled_instructions.clear();
+	account_keys.clear();
+	meta_list.clear();
 
 	// blockhash + number of accounts + compiled instruction size
 	const unsigned int minimum_remaining_size = BLOCKHASH_LENGTH + 1 + 1;
@@ -122,7 +125,6 @@ void Message::create(const PackedByteArray &bytes) {
 	read_accounts_from_bytes(bytes, writable_unsigned_accounts, false, true, cursor);
 	read_accounts_from_bytes(bytes, num_readonly_unsigned_accounts, false, false, cursor);
 
-	meta_list.sort();
 	recalculate_headers();
 
 	latest_blockhash = Pubkey::string_from_variant(bytes.slice(cursor, cursor + static_cast<int64_t>(PUBKEY_LENGTH)));


### PR DESCRIPTION
Browser wallets fail whenever they alter the transactions. Since most wallets tend to modify the transactions more often, this commit introduces a way to adapt to the changes made by browser wallets. A method for detecting modifications is implemented. When modifications are detected, the transaction will be rebuilt from the browser wallet.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
