### PR TITLE
Fix wallet adapter signing on deserialized transaction

### DIFF
--- a/include/transaction/transaction.hpp
+++ b/include/transaction/transaction.hpp
@@ -59,10 +59,11 @@ private:
 	static bool are_all_bytes_zeroes(const PackedByteArray &bytes);
 
 	void _get_property_list(List<PropertyInfo> *p_list) const;
-	void _signer_signed(const PackedByteArray &signature);
+	void _signer_signed(const PackedByteArray &signature, const int32_t index);
 	void _signer_failed();
 
 	bool is_phantom_payer() const;
+	bool has_valid_payer() const;
 	void create_message();
 	void check_fully_signed();
 	void reset_state();
@@ -80,7 +81,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	Transaction() = default;
+	Transaction();
 	void from_bytes(const PackedByteArray &bytes);
 
 	static Variant new_from_bytes(const PackedByteArray &bytes);

--- a/src/candy_machine/candy_guard.cpp
+++ b/src/candy_machine/candy_guard.cpp
@@ -184,7 +184,6 @@ Variant MplCandyGuard::mint(
 	result->append_meta(*memnew(AccountMeta(new_pid, false, false)));
 
 	TypedArray<AccountMeta> mint_arg_accounts = Object::cast_to<CandyGuardAccessList>(candy_guard_acl)->get_group(label).get_mint_arg_accounts(receiver, candy_machine_id, guard_account_id);
-	std::cout << "SIIZE " << mint_arg_accounts.size() << std::endl;
 	for (unsigned int i = 0; i < mint_arg_accounts.size(); i++) {
 		result->append_meta(*memnew(AccountMeta(mint_arg_accounts[i])));
 	}

--- a/src/transaction/merged_account_metas.cpp
+++ b/src/transaction/merged_account_metas.cpp
@@ -16,17 +16,17 @@ Variant MergedAccountMetas::preferred_signer(const Variant &left, const Variant 
 	Object *left_object = nullptr;
 	Object *right_object = nullptr;
 
+	const Variant left_pubkey = Pubkey::new_from_variant(left);
 	if (left.get_type() == Variant::OBJECT) {
 		left_object = static_cast<Object *>(left);
 	} else {
-		const Variant left_pubkey = Pubkey::new_from_variant(left);
 		ERR_FAIL_COND_V_EDMSG_CUSTOM(left_pubkey.get_type() != Variant::OBJECT, nullptr, "Invalid signer input type.");
 		left_object = static_cast<Object *>(left_pubkey);
 	}
+	const Variant right_pubkey = Pubkey::new_from_variant(right);
 	if (right.get_type() == Variant::OBJECT) {
 		right_object = static_cast<Object *>(right);
 	} else {
-		const Variant right_pubkey = Pubkey::new_from_variant(right);
 		ERR_FAIL_COND_V_EDMSG_CUSTOM(right_pubkey.get_type() != Variant::OBJECT, nullptr, "Invalid signer input type.");
 		right_object = static_cast<Object *>(right_pubkey);
 	}
@@ -85,7 +85,7 @@ void MergedAccountMetas::from_instructions(const TypedArray<Instruction> &instru
 	for (unsigned int i = 0; i < instructions.size(); i++) {
 		auto *element = Object::cast_to<Instruction>(instructions[i]);
 
-		const TypedArray<AccountMeta> &account_metas = element->get_accounts();
+		const TypedArray<AccountMeta> account_metas = element->get_accounts();
 		const AccountMeta *pid_meta = memnew_custom(AccountMeta(element->get_program_id(), false, false));
 		add(pid_meta);
 


### PR DESCRIPTION
Wallet adapter signing was locked to use payer wallet adapter. This commit finds the signing wallet adapter by providing signer index to sign confirm callback.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
