### PR TITLE
Fix crash on set payer on deserialized transaction

### DIFF
--- a/example/Transactions/project.godot
+++ b/example/Transactions/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Transactions"
 run/main_scene="res://transaction_example.tscn"
-config/features=PackedStringArray("4.3", "GL Compatibility")
+config/features=PackedStringArray("4.4", "GL Compatibility")
 config/icon="res://icon.svg"
 
 [rendering]

--- a/example/Transactions/transaction_example.gd
+++ b/example/Transactions/transaction_example.gd
@@ -4,7 +4,7 @@ extends VBoxContainer
 @onready var payer: Keypair = Keypair.new_from_file("res://payer.json")
 const LAMPORTS_PER_SOL = 1000000000
 
-const TOTAL_CASES := 13
+const TOTAL_CASES := 14
 var passed_test_mask := 0
 
 
@@ -249,6 +249,34 @@ func string_as_account_input():
 	PASS(12)
 
 
+func handle_set_payer_on_deserialized_transaction():
+	var receiver: Pubkey = Pubkey.new_from_string("78GVwUb8ojcJVrEVkwCU5tfUKTfJuiazRrysGwgjqsif")
+	var tx = Transaction.new()
+
+	add_child(tx)
+	
+	tx.set_payer(payer)
+	
+	var ix: Instruction = SystemProgram.transfer(payer, receiver, LAMPORTS_PER_SOL / 10)
+	tx.add_instruction(ix)
+
+	tx.update_latest_blockhash()
+
+	tx.sign()
+	
+	var new_tx = Transaction.new_from_bytes(tx.serialize())
+	
+	var random_payer = Keypair.new_random()
+	new_tx.set_payer(random_payer)
+	
+	var original = tx.serialize()
+	var reconstructed = new_tx.serialize()
+
+	assert(original == reconstructed)
+
+	PASS(13)
+
+
 func _ready():
 	# Use a local cluster for unlimited Solana airdrops.
 	# SolanaClient defaults to devnet cluster URL if not specified.
@@ -265,6 +293,7 @@ func _ready():
 	blockhash_before_instruction()
 	transaction_from_bytes()
 	string_as_account_input()
+	handle_set_payer_on_deserialized_transaction()
 
 
 func _on_timeout_timeout():

--- a/example/Transactions/transaction_example.gd.uid
+++ b/example/Transactions/transaction_example.gd.uid
@@ -1,0 +1,1 @@
+uid://smdtiu6pfnni

--- a/example/Transactions/transaction_example.tscn
+++ b/example/Transactions/transaction_example.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://f7w6n866ytk6"]
 
-[ext_resource type="Script" path="res://transaction_example.gd" id="1_5f21j"]
+[ext_resource type="Script" uid="uid://smdtiu6pfnni" path="res://transaction_example.gd" id="1_5f21j"]
 
 [node name="TransactionExample" type="VBoxContainer"]
 anchors_preset = 8

--- a/include/solana_utils.hpp
+++ b/include/solana_utils.hpp
@@ -52,6 +52,11 @@ namespace godot {
 	ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                           \
 	/* NOLINTEND(llvm-else-after-return,readability-else-after-return) */
 
+#define WARN_PRINT_ED_CUSTOM(m_msg)                                        \
+	/* NOLINTBEGIN(llvm-else-after-return,readability-else-after-return)*/ \
+	WARN_PRINT_ED(m_msg)                                                   \
+	/* NOLINTEND(llvm-else-after-return,readability-else-after-return) */
+
 #define WARN_PRINT_ONCE_ED_CUSTOM(m_msg)                                   \
 	/* NOLINTBEGIN(llvm-else-after-return,readability-else-after-return)*/ \
 	WARN_PRINT_ONCE_ED(m_msg)                                              \

--- a/include/transaction/transaction.hpp
+++ b/include/transaction/transaction.hpp
@@ -55,6 +55,7 @@ private:
 	bool append_budget_instructions = true;
 
 	bool skip_preflight = false;
+	bool deserialized = false;
 
 	static bool are_all_bytes_zeroes(const PackedByteArray &bytes);
 

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -34,6 +34,10 @@
 #include "dialogs/menubar_helper.hpp"
 #include "doc_data_godot-solana-sdk.gen.h"
 #include "hash.hpp"
+#include "honeycomb/enums_generated.hpp"
+#include "honeycomb/honeycomb.hpp"
+#include "honeycomb/honeycomb_generated.hpp"
+#include "honeycomb/types/index_generated.hpp"
 #include "instruction.hpp"
 #include "keypair.hpp"
 #include "meta_data/collection.hpp"
@@ -54,10 +58,6 @@
 #include "system_program.hpp"
 #include "transaction.hpp"
 #include "wallet_adapter.hpp"
-#include "honeycomb/honeycomb.hpp"
-#include "honeycomb/honeycomb_generated.hpp"
-#include "honeycomb/types/index_generated.hpp"
-#include "honeycomb/enums_generated.hpp"
 
 namespace godot {
 namespace {
@@ -93,7 +93,7 @@ void load_idl_from_string(const String &json_content) {
 }
 
 void initialize_solana_sdk_module(ModuleInitializationLevel p_level) {
-	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR && (_doc_data_size > 0)) {
 		auto editor_help_load_xml_from_utf8_chars_and_len = reinterpret_cast<GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8CharsAndLen>(internal::gdextension_interface_get_proc_address("editor_help_load_xml_from_utf8_chars_and_len")); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 		editor_help_load_xml_from_utf8_chars_and_len(static_cast<const char *>(_doc_data), _doc_data_size);
 	}
@@ -140,27 +140,11 @@ void initialize_solana_sdk_module(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<HoneyComb>();
 
 	REGISTER_HONEYCOMB_TYPES
-  REGISTER_HONEYCOMB_ENUM
+	REGISTER_HONEYCOMB_ENUM
 
 	ClassDB::register_class<MenuBarHelper>();
 	ClassDB::register_class<AddCustomIdlDialog>();
-	//ClassDB::register_class<GenericAnchorNode>();
-	//ClassDB::register_class<GenericAnchorResource>();
-	GenericAnchorResource::set_class_name("GenericAnchorResource");
 	ClassDB::register_class<GenericAnchorResource>();
-	StringName *abc = memnew(StringName("GenericAnchorResource"));
-
-	//internal::gdextension_interface_classdb_unregister_extension_class(internal::library, abc->_native_ptr());
-
-	//AddCustomIdlDialog::load_idl("res://testidl.json");
-
-	Dictionary reso;
-	Dictionary struct_info;
-	reso["name"] = "GenericAnchorResource";
-	struct_info["fields"] = Array();
-	reso["type"] = struct_info;
-	//GenericAnchorResource::bind_anchor_resource(reso);
-	GenericAnchorResource::set_class_name("aaa");
 
 	add_setting("solana_sdk/client/default_url", Variant::Type::STRING, "https://api.devnet.solana.com");
 	add_setting("solana_sdk/client/default_http_port", Variant::Type::INT, HTTPS_PORT);


### PR DESCRIPTION
When calling set_payer on a deserialized transaction, the signature state is cleared. This will also cause the transaction message to be recreated. This doesn't work since the data to create the message is unavailable. These changes adds a flag that indicates if the transaction is deserialized. If it is the set_payer method will warn user and do nothing.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
