### PR TITLE
Add WalletAdapterAndroid to build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,11 +210,20 @@ jobs:
         name: ${{ github.event.repository.name }}
         path: ./bin
 
+    - name: Set up Python
+      uses: actions/setup-python@v2
+
+    - name: Set up SCons
+      shell: bash
+      run: |
+        python -c "import sys; print(sys.version)"
+        python -m pip install scons==4.8
+
     - name: Package Solanakit
       shell: sh
       run: |
-        ls -l bin/
-        cp -r bin addons/SolanaSDK/
+        scons WalletAdapterAndroid
+        scons assemble
       
     - name: Upload SolanaKit
       uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,8 +1,10 @@
 name: Deploy Docs
 on:
-  push:
-    branches:
-    - master
+  workflow_dispatch
+# TODO(VirAx): Enable this when deploy job is fixed.
+#  push:
+#    branches:
+#    - master
 permissions:
   contents: write
 

--- a/SConstruct
+++ b/SConstruct
@@ -457,4 +457,5 @@ else:
     AlwaysBuild(bin_target)
     AlwaysBuild(gdext_target)
 
+    env.Command("assemble", GDEXT_FILE, [copy_bin_action, copy_aar_action])
     env.Alias("addon", [ANDROID_PLUGIN_DESTINATION, gdext_target])

--- a/android/SConscript
+++ b/android/SConscript
@@ -10,10 +10,12 @@ aar_library_release = os.path.join(OUTPUT_FOLDER, f'{PLUGIN_NAME}-release.aar')
 
 gradle_assemble_action = env.Action("cd android && ./gradlew assemble", cmdstr="Running Gradle wrapper")
 
-gradle_command = env.Command(
+gradle_command_raw = env.Command(
     target=[aar_library_debug, aar_library_release],
     source=None,
     action=gradle_assemble_action,
 )
+
+gradle_command = env.Alias('WalletAdapterAndroid', gradle_command_raw)
 
 Return('gradle_command')


### PR DESCRIPTION
The build action is not packaging android plugin. This commit fixes that by adding a new SCons command, assemble. The github action is modified to use the assemble command instead of cp shell command.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
