### PR TITLE
Add additional signals to SolanaClient

### DIFF
--- a/addons/SolanaSDK/Dialogs/arweave_manager.gd
+++ b/addons/SolanaSDK/Dialogs/arweave_manager.gd
@@ -65,7 +65,7 @@ func start_tx_simulation():
 	var upload_price = int(str_to_var(upload_price_str[3].get_string_from_ascii()) * 1000000000 * 1.05)
 	
 	$SolanaClient.get_latest_blockhash()
-	var bh = await $SolanaClient.http_response_received
+	var bh = (await $SolanaClient.http_request_completed)[1]
 	if not bh.has("result"):
 		display_error("Failed to fetch blockhash: " + str(bh))
 		return
@@ -170,7 +170,7 @@ func _on_create_button_pressed() -> void:
 	var upload_price = int(str_to_var(upload_price_str[3].get_string_from_ascii()) * 1000000000 * 1.05)
 	
 	$SolanaClient2.get_latest_blockhash()
-	var bh = await $SolanaClient2.http_response_received
+	var bh = (await $SolanaClient2.http_request_completed)[1]
 	if not bh.has("result"):
 		display_error("Failed to fetch blockhash: " + str(bh))
 		return

--- a/addons/SolanaSDK/Dialogs/create_token.gd
+++ b/addons/SolanaSDK/Dialogs/create_token.gd
@@ -21,7 +21,7 @@ func get_create_instructions():
 	print(auth.get_public_string())
 	
 	$SolanaClient.get_minimum_balance_for_rent_extemption(TokenProgram.TOKEN_MINT_SIZE);
-	var response = await $SolanaClient.http_response_received
+	var response = (await $SolanaClient.http_request_completed)[1]
 
 	if not response.has("result"):
 		push_error("Invalid response from RPC server")

--- a/addons/SolanaSDK/Dialogs/simple_nft_creator.gd
+++ b/addons/SolanaSDK/Dialogs/simple_nft_creator.gd
@@ -34,7 +34,7 @@ func minumum_balance_for_rent_extemtion(data_size):
 	add_child(client)
 	client.url_override = $Transaction.url_override
 	client.get_minimum_balance_for_rent_extemption(data_size)
-	var result = await client.http_response_received
+	var result = (await client.http_request_completed)[1]
 	print(result)
 	assert(result.has("result"))
 	remove_child(client)
@@ -117,7 +117,7 @@ func get_arweave_transaction(payer_kp: Keypair, file_name: String, file_data: Pa
 	var upload_price = int(str_to_var(upload_price_str[3].get_string_from_ascii()) * 1000000000 * 1.05)
 	
 	$SolanaClient2.get_latest_blockhash()
-	var bh = await $SolanaClient2.http_response_received
+	var bh = (await $SolanaClient2.http_request_completed)[1]
 	if not bh.has("result"):
 		display_error(arweave_error + "Failed to fetch blockhash: " + str(bh))
 		return null
@@ -186,7 +186,7 @@ func upload_file_to_arweave(payer_kp: Keypair, file_name: String, file_data):
 	var upload_price = int(str_to_var(upload_price_str[3].get_string_from_ascii()) * 1000000000 * 1.05)
 	
 	$SolanaClient2.get_latest_blockhash()
-	var bh = await $SolanaClient2.http_response_received
+	var bh = (await $SolanaClient2.http_request_completed)[1]
 	if not bh.has("result"):
 		display_error(arweave_error + "Failed to fetch blockhash: " + str(bh))
 		return

--- a/addons/SolanaSDK/Optional/SolanaService/Scripts/Managers/candy_machine_manager.gd
+++ b/addons/SolanaSDK/Optional/SolanaService/Scripts/Managers/candy_machine_manager.gd
@@ -132,7 +132,7 @@ func fetch_core_candy_machine(candy_machine_key: Pubkey) -> Dictionary:
 	add_child(client)
 	client.get_account_info(candy_machine_key.to_string())
 	var result := {}
-	var data: Dictionary = await client.http_response_received
+	var data: Dictionary = (await client.http_request_completed)[1]
 
 	assert(data.has("result"))
 	assert(data["result"].has("value"))

--- a/addons/SolanaSDK/Optional/SolanaService/Scripts/Managers/solana_service.gd
+++ b/addons/SolanaSDK/Optional/SolanaService/Scripts/Managers/solana_service.gd
@@ -122,7 +122,7 @@ func spawn_program_instance(original_program:AnchorProgram)->AnchorProgram:
 func get_account_info(account:Pubkey, parsed:bool=true) -> Dictionary:
 	var client:SolanaClient = spawn_client_instance()
 	client.get_account_info(account.to_string())
-	var response_dict:Dictionary = await client.http_response_received
+	var response_dict:Dictionary = (await client.http_request_completed)[1]
 	client.queue_free()
 	
 	if !parsed or !response_dict.has("result"):
@@ -142,7 +142,7 @@ func get_account_info(account:Pubkey, parsed:bool=true) -> Dictionary:
 func get_transaction_info(tx_signature:String):
 	var client:SolanaClient = spawn_client_instance()
 	client.get_transaction(tx_signature)
-	var response_dict:Dictionary = await client.http_response_received
+	var response_dict:Dictionary = (await client.http_request_completed)[1]
 	client.queue_free()
 	if response_dict.size() == 0 or !response_dict.has("result"):
 		return null
@@ -151,7 +151,7 @@ func get_transaction_info(tx_signature:String):
 func get_airdrop(address:String,sol_lamport_amount:int) -> void:
 	var client:SolanaClient = spawn_client_instance()
 	client.request_airdrop(address,sol_lamport_amount)
-	var response_dict:Dictionary = await client.http_response_received
+	var response_dict:Dictionary = (await client.http_request_completed)[1]
 	print(response_dict)
 	
 	client.queue_free()
@@ -159,7 +159,7 @@ func get_airdrop(address:String,sol_lamport_amount:int) -> void:
 func get_largest_account(mint:Pubkey) -> Pubkey:
 	var client:SolanaClient = spawn_client_instance()
 	client.get_token_largest_account(mint.to_string())
-	var response_dict:Dictionary = await client.http_response_received
+	var response_dict:Dictionary = (await client.http_request_completed)[1]
 	client.queue_free()
 	
 	var token_account:Pubkey = null
@@ -172,7 +172,7 @@ func get_largest_account(mint:Pubkey) -> Pubkey:
 func is_blockhash_valid(blockhash:String):
 	var client:SolanaClient = spawn_client_instance()
 	client.is_blockhash_valid(blockhash)
-	var response_dict:Dictionary = await client.http_response_received
+	var response_dict:Dictionary = (await client.http_request_completed)[1]
 	print(response_dict)
 	if !response_dict.has("result"):
 		return null
@@ -182,7 +182,7 @@ func get_balance(address_to_check:String,token_address:String="") -> float:
 	var client:SolanaClient = spawn_client_instance()
 	if token_address == "":
 		client.get_balance(address_to_check)
-		var response_dict:Dictionary = await client.http_response_received
+		var response_dict:Dictionary = (await client.http_request_completed)[1]
 		client.queue_free()
 		var balance = response_dict["result"]["value"] / 1000000000
 		return balance
@@ -196,7 +196,7 @@ func get_balance(address_to_check:String,token_address:String="") -> float:
 func get_ata_balance(associated_token_account:String) -> float:
 	var client:SolanaClient = spawn_client_instance()
 	client.get_token_account_balance(associated_token_account)
-	var response_dict:Dictionary = await client.http_response_received
+	var response_dict:Dictionary = (await client.http_request_completed)[1]
 	client.queue_free()
 
 	if response_dict.has("error"):
@@ -210,7 +210,7 @@ func get_ata_balance(associated_token_account:String) -> float:
 func get_token_decimals(token_address:String)->int:
 	var client:SolanaClient = spawn_client_instance()
 	client.get_token_supply(token_address)
-	var response_dict:Dictionary = await client.http_response_received
+	var response_dict:Dictionary = (await client.http_request_completed)[1]
 	client.queue_free()
 	
 	if response_dict.has("error"):
@@ -223,7 +223,7 @@ func simulate_transaction(transaction:Transaction) -> Dictionary:
 	var client:SolanaClient = spawn_client_instance()
 	var serialized_tx:String = SolanaUtils.bs64_encode(transaction.serialize())
 	client.simulate_transaction(serialized_tx,false,false,[],"base64")
-	var result = await client.http_response_received
+	var result = (await client.http_request_completed)[1]
 	client.queue_free()
 	
 	if result.size() == 0 or result.has("error"):
@@ -236,7 +236,7 @@ func simulate_transaction(transaction:Transaction) -> Dictionary:
 func is_transaction_confirmed(tx_signatures:Array, commitment:TransactionManager.Commitment) -> bool:
 	var client:SolanaClient = spawn_client_instance()
 	client.get_signature_statuses(tx_signatures,false)
-	var response_dict:Dictionary = await client.http_response_received
+	var response_dict:Dictionary = (await client.http_request_completed)[1]
 	if !response_dict.has("result"):
 		return false
 	
@@ -266,7 +266,7 @@ func is_transaction_confirmed(tx_signatures:Array, commitment:TransactionManager
 func get_associated_token_account(address_to_check:String,token_address:String) -> Pubkey:
 	var client:SolanaClient = spawn_client_instance()
 	client.get_token_accounts_by_owner(address_to_check,token_address,ATA_TOKEN_PID)
-	var response_dict:Dictionary = await client.http_response_received
+	var response_dict:Dictionary = (await client.http_request_completed)[1]
 	client.queue_free()
 	
 	var ata:String
@@ -311,7 +311,7 @@ func get_asset_data(asset_id:Pubkey) -> Dictionary:
 		return {}
 	var client:SolanaClient = spawn_client_instance()
 	client.get_asset(asset_id)
-	var response_dict:Dictionary = await client.http_response_received
+	var response_dict:Dictionary = (await client.http_request_completed)[1]
 	client.queue_free()
 
 	if response_dict.has("error"):
@@ -332,7 +332,7 @@ func get_wallet_assets_data(wallet_to_check:Pubkey,asset_limit:int=1000) -> Arra
 		var client:SolanaClient = spawn_client_instance()
 		client.get_assets_by_owner(wallet_to_check,page_id,asset_limit,true)
 		
-		var response_dict:Dictionary = await client.http_response_received
+		var response_dict:Dictionary = (await client.http_request_completed)[1]
 		client.queue_free()
 		if response_dict.has("error"):
 			push_error("Error fetching DAS assets data, stopping paging operation")
@@ -361,7 +361,7 @@ func get_collection_assets_data(nft_owner:Pubkey,collection_mint:Pubkey,asset_li
 	while true:
 		var client:SolanaClient = spawn_client_instance()
 		client.get_assets_by_group("collection_id",collection_mint,page_id,asset_limit)
-		var response_dict:Dictionary = await client.http_response_received
+		var response_dict:Dictionary = (await client.http_request_completed)[1]
 		client.queue_free()
 		if response_dict.has("error"):
 			push_error("Error fetching DAS collection assets data, stopping paging operation")
@@ -376,12 +376,12 @@ func get_collection_assets_data(nft_owner:Pubkey,collection_mint:Pubkey,asset_li
 func get_token_accounts(wallet_to_check:Pubkey) -> Array[Dictionary]:
 	var client:SolanaClient = spawn_client_instance()
 	client.get_token_accounts_by_owner(wallet_to_check.to_string(),null,TOKEN_PID)
-	var response_dict:Dictionary = await client.http_response_received
+	var response_dict:Dictionary = (await client.http_request_completed)[1]
 	client.queue_free()
 	
 	client = spawn_client_instance()
 	client.get_token_accounts_by_owner(wallet_to_check.to_string(),null,TOKEN22_PID)
-	var response_dict2:Dictionary = await client.http_response_received
+	var response_dict2:Dictionary = (await client.http_request_completed)[1]
 	client.queue_free()
 	
 	if response_dict.has("error") or response_dict2.has("error"):

--- a/addons/SolanaSDK/Scenes/TransactionSimulator.tscn
+++ b/addons/SolanaSDK/Scenes/TransactionSimulator.tscn
@@ -140,6 +140,6 @@ wrap_mode = 1
 
 [node name="Transaction" type="Transaction" parent="."]
 
-[connection signal="http_response_received" from="SolanaClient" to="." method="_on_solana_client_http_response_received"]
-[connection signal="http_response_received" from="SolanaClient2" to="." method="_on_solana_client_2_http_response_received"]
+[connection signal="http_request_completed" from="SolanaClient" to="." method="_on_solana_client_http_response_received"]
+[connection signal="http_request_completed" from="SolanaClient2" to="." method="_on_solana_client_2_http_response_received"]
 [connection signal="timeout" from="LoadingLabel/Timer" to="LoadingLabel" method="_on_timer_timeout"]

--- a/addons/SolanaSDK/Scenes/transaction_simulator.gd
+++ b/addons/SolanaSDK/Scenes/transaction_simulator.gd
@@ -40,7 +40,7 @@ func get_lamport_offset():
 		return from_lamports - result_lamports
 	return 0
 
-func _on_solana_client_http_response_received(response: Dictionary) -> void:
+func _on_solana_client_http_response_received(error: int, response: Dictionary) -> void:
 	if not response.has("result"):
 		display_error("Unexpected response: " + str(response))
 		return
@@ -74,7 +74,7 @@ func _on_solana_client_http_response_received(response: Dictionary) -> void:
 	before_received = true
 	check_done()
 
-func _on_solana_client_2_http_response_received(response: Dictionary) -> void:
+func _on_solana_client_2_http_response_received(error: int, response: Dictionary) -> void:
 	if not response.has("result"):
 		display_error("Unexpected response: " + str(response))
 		return

--- a/example/CandyMachine/candy_machine_demo.gd
+++ b/example/CandyMachine/candy_machine_demo.gd
@@ -21,7 +21,7 @@ func minumum_balance_for_rent_extemtion(data_size):
 	var client = SolanaClient.new()
 	add_child(client)
 	client.get_minimum_balance_for_rent_extemption(data_size)
-	var result = await client.http_response_received
+	var result = (await client.http_request_completed)[1]
 	assert(result.has("result"))
 	remove_child(client)
 	return result['result']

--- a/example/MplCore/MplCore.gd
+++ b/example/MplCore/MplCore.gd
@@ -36,7 +36,7 @@ func minumum_balance_for_rent_extemtion(data_size):
 	var client = SolanaClient.new()
 	add_child(client)
 	client.get_minimum_balance_for_rent_extemption(data_size)
-	var result = await client.http_response_received
+	var result = (await client.http_request_completed)[1]
 	assert(result.has("result"))
 	remove_child(client)
 	return result['result']

--- a/example/MplMetadata/metadata_test.gd
+++ b/example/MplMetadata/metadata_test.gd
@@ -14,7 +14,9 @@ func minumum_balance_for_rent_extemtion(data_size):
 	var client = SolanaClient.new()
 	add_child(client)
 	client.get_minimum_balance_for_rent_extemption(data_size)
-	var result = await client.http_response_received
+	var signal_data = await client.http_request_completed
+	var error = signal_data[0]
+	var result = signal_data[1]
 	assert(result.has("result"))
 	remove_child(client)
 	return result['result']

--- a/example/Token2022/token_2022_demo.gd
+++ b/example/Token2022/token_2022_demo.gd
@@ -20,7 +20,7 @@ func minumum_balance_for_rent_extemtion(data_size):
 	var client = SolanaClient.new()
 	add_child(client)
 	client.get_minimum_balance_for_rent_extemption(data_size)
-	var result = await client.http_response_received
+	var result = (await client.http_request_completed)[1]
 	assert(result.has("result"))
 	remove_child(client)
 	return result['result']

--- a/example/Tokens/TokenDemo.gd
+++ b/example/Tokens/TokenDemo.gd
@@ -34,7 +34,7 @@ func minumum_balance_for_rent_extemtion(data_size):
 	var client = SolanaClient.new()
 	add_child(client)
 	client.get_minimum_balance_for_rent_extemption(data_size)
-	var result = await client.http_response_received
+	var result = (await client.http_request_completed)[1]
 	assert(result.has("result"))
 	remove_child(client)
 	return result['result']

--- a/example/Transactions/transaction_example.gd
+++ b/example/Transactions/transaction_example.gd
@@ -20,7 +20,7 @@ func transaction_example_airdrop_to():
 	
 
 	$SolanaClient.request_airdrop(payer.get_public_string(), 3 * LAMPORTS_PER_SOL)
-	var response = await $SolanaClient.http_response_received
+	var response = (await $SolanaClient.http_request_completed)[1]
 
 	# Error check the RPC result
 	assert(response.has("result"))

--- a/example/honeycomb/common/assets.gd
+++ b/example/honeycomb/common/assets.gd
@@ -253,7 +253,7 @@
 	#var solana_client = SolanaClient.new()
 	#add_child(solana_client)
 	#solana_client.get_minimum_balance_for_rent_extemption(data_size)
-	#var result = await solana_client.http_response_received
+	#var result = (await solana_client.http_request_completed)[1]
 	#assert(result.has("result"))
 	#remove_child(solana_client)
 	#return result['result']

--- a/example/honeycomb/common/base.gd
+++ b/example/honeycomb/common/base.gd
@@ -179,7 +179,7 @@ func assemble_character(client: HoneyComb, project_address: String, assembler_co
 	add_child(solana_client)
 	# Step 1: Get Pre-Balance
 	solana_client.get_balance(payer_keypair.get_public_string())
-	var pre_balance = await solana_client.http_response_received
+	var pre_balance = (await solana_client.http_request_completed)[1]
 	print("pre_balance: ",pre_balance)
 	
 	# Step 2: Create Assemble Character Transaction
@@ -208,7 +208,7 @@ func assemble_character(client: HoneyComb, project_address: String, assembler_co
 
 	# Step 4: Get Post-Balance
 	solana_client.get_balance(payer_keypair.get_public_string())
-	var post_balance = await solana_client.http_response_received
+	var post_balance = (await solana_client.http_request_completed)[1]
 	print("post_balance: ",post_balance)
 	 ## assert(pre_balance.result.value == post_balance.result.value, "Expected pre_balance to be equal to post_balance, but they are different!")
 

--- a/example/honeycomb/common/utils.gd
+++ b/example/honeycomb/common/utils.gd
@@ -262,7 +262,7 @@ func request_airdrop_func(wallet: String, amount: int):
 	var solana_client = SolanaClient.new()
 	add_child(solana_client)
 	solana_client.request_airdrop(wallet, amount)
-	var response = await solana_client.http_response_received
+	var response = (await solana_client.http_request_completed)[1]
 	#print("response: ",response)
 	if not response or not response.has("result"):
 		print("Failed to receive airdrop")

--- a/example/honeycomb/tests/test_charater_wrap.gd
+++ b/example/honeycomb/tests/test_charater_wrap.gd
@@ -95,7 +95,7 @@ func update_character_traits():
 	
 	# Step 1: Get Pre-Balance
 	solana_client.get_balance(utils.user_keypair.get_public_string())
-	var pre_balance = await solana_client.http_response_received
+	var pre_balance = (await solana_client.http_request_completed)[1]
 	print("pre_balance: ", pre_balance)
 
 	# Step 2: Create Update Character Traits Transaction
@@ -126,7 +126,7 @@ func update_character_traits():
 
 	# Step 4: Get Post-Balance
 	solana_client.get_balance(utils.user_keypair.get_public_string())
-	var post_balance = await solana_client.http_response_received
+	var post_balance = (await solana_client.http_request_completed)[1]
 	print("post_balance: ", post_balance)
 	 ## assert(pre_balance.result.value == post_balance.result.value, "Expected pre_balance to be equal to post_balance, but they are different!")
 
@@ -157,7 +157,7 @@ func unwrap_character():
 	print("Running test: Unwrap Character")
 	
 	solana_client.get_balance(utils.user_keypair.get_public_string())
-	var pre_balance = await solana_client.http_response_received
+	var pre_balance = (await solana_client.http_request_completed)[1]
 	print("pre_balance: ",pre_balance)
 	
 	
@@ -178,7 +178,7 @@ func unwrap_character():
 	
 	
 	solana_client.get_balance(utils.user_keypair.get_public_string())
-	var post_balance = await solana_client.http_response_received
+	var post_balance = (await solana_client.http_request_completed)[1]
 	print("post_balance: ",post_balance)
 	 ## assert(pre_balance.result.value == post_balance.result.value, "Expected pre_balance to be equal to post_balance, but they are different!")
 

--- a/include/account.hpp
+++ b/include/account.hpp
@@ -50,7 +50,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	Account();
+	Account() = default;
 
 	/**
 	 * @_set{Account}

--- a/include/anchor/anchor_program.hpp
+++ b/include/anchor/anchor_program.hpp
@@ -58,9 +58,9 @@ private:
 	static Variant idl_address(const Variant &pid);
 
 	bool load_from_pid(const String &pid);
-	void idl_from_pid_callback(const Dictionary &rpc_result);
-	void fetch_account_callback(const Dictionary &rpc_result);
-	void fetch_all_accounts_callback(const Dictionary &rpc_result);
+	void idl_from_pid_callback(Error error, const Dictionary &rpc_result);
+	void fetch_account_callback(Error error, const Dictionary &rpc_result);
+	void fetch_all_accounts_callback(Error error, const Dictionary &rpc_result);
 	void extract_idl_from_data(const Array &data_info);
 	Dictionary parse_account_data(const Dictionary &account_data, const Dictionary &reference, bool emit_decoded_account = false);
 

--- a/include/anchor/generic_anchor_resource.hpp
+++ b/include/anchor/generic_anchor_resource.hpp
@@ -115,6 +115,14 @@ protected:
 	// NOLINTEND(cppcoreguidelines-non-private-member-variables-in-classes,misc-non-private-member-variables-in-classes)
 
 	/**
+	 * @brief Check if class is an extension class.
+	 *
+	 * @return true If class is an extension class.
+	 * @return false Otherwise.
+	 */
+	bool _is_extension_class() const override;
+
+	/**
 	 * @brief Get extension class name.
 	 *
 	 * @return const StringName* Pointer to class name.

--- a/include/candy_machine/candy_machine.hpp
+++ b/include/candy_machine/candy_machine.hpp
@@ -149,9 +149,10 @@ public:
 	/**
 	 * @brief Called when CandyMachineData is fetched.
 	 *
+	 * @param error Error code of the operation.
 	 * @param params Account data.
 	 */
-	void fetch_account_callback(const Dictionary &params);
+	void fetch_account_callback(Error error, const Dictionary &params);
 
 	/**
 	 * @brief Get the MplCandyMachine program ID.

--- a/include/custom_class_management/generic_type.hpp
+++ b/include/custom_class_management/generic_type.hpp
@@ -65,7 +65,7 @@ protected:
 	 * @return true If class is an extension class.
 	 * @return false Otherwise.
 	 */
-	[[nodiscard]] bool _is_extension_class() const final { // NOLINT(portability-template-virtual-member-function,-warnings-as-errors)
+	[[nodiscard]] bool _is_extension_class() const override {
 		return true;
 	}
 

--- a/include/instructions/mpl_token_metadata.hpp
+++ b/include/instructions/mpl_token_metadata.hpp
@@ -21,7 +21,7 @@ private:
 
 	bool pending_fetch = false;
 
-	void metadata_callback(const Dictionary &rpc_result);
+	void metadata_callback(Error error, const Dictionary &rpc_result);
 
 protected:
 	/**

--- a/include/shdwdrive.hpp
+++ b/include/shdwdrive.hpp
@@ -145,7 +145,8 @@ private:
 	void fetch_storage_account_callback(const Dictionary &params);
 	void upload_file_callback(int result, int response_code, const PackedStringArray &headers, const PackedByteArray &body);
 
-	void emit_simulation_response(const Dictionary &response);
+	void emit_simulation_response(Error error, const Dictionary &response);
+	void handle_http_error(const Variant &error_info);
 
 	static uint64_t human_size_to_bytes(const String &human_size);
 
@@ -259,9 +260,10 @@ public:
 	/**
 	 * @brief Called when all storage accounts are being fetched.
 	 *
+	 * @param error Error code of the operation.
 	 * @param response Get account info request response from RPC node.
 	 */
-	void get_multiple_accounts_callback(const Dictionary &response);
+	void get_multiple_accounts_callback(Error error, const Dictionary &response);
 
 	/**
 	 * @brief Create a new user info PDA Pubkey.

--- a/include/solana_client/rpc_multi_http_request_client.hpp
+++ b/include/solana_client/rpc_multi_http_request_client.hpp
@@ -42,9 +42,10 @@ public:
 	 * @param request_body Request to send.
 	 * @param parsed_url URL of the request.
 	 * @param callback Callback to call on response received.
+	 * @param error_callback Callback to call if an error occur.
 	 * @param timeout Timeout of request.
 	 */
-	void asynchronous_request(const Dictionary &request_body, const Dictionary &parsed_url, const Callable &callback, float timeout = DEFAULT_REQUEST_TIMEOUT);
+	void asynchronous_request(const Dictionary &request_body, const Dictionary &parsed_url, const Callable &callback, const Callable &error_callback, float timeout = DEFAULT_REQUEST_TIMEOUT);
 };
 
 } //namespace godot

--- a/include/solana_client/rpc_single_http_request_client.hpp
+++ b/include/solana_client/rpc_single_http_request_client.hpp
@@ -24,6 +24,7 @@ typedef struct { // NOLINT(modernize-use-using,cppcoreguidelines-pro-type-member
 	double timeout; ///< timeout of request.
 	int request_identifier; ///< ID to pass with the RPC request.
 	Callable callback; ///< Callback that will be called when request response received.
+	Callable error_callback; ///< Callback that will be called when an error occurred.
 } RequestData;
 
 /**
@@ -49,7 +50,7 @@ private:
 
 	Error connect_to();
 	Error send_next_request();
-	void finalize_faulty();
+	void finalize_faulty(Error error);
 	void finalize_request(const Dictionary &response);
 
 protected:
@@ -85,9 +86,10 @@ public:
 	 * @param request_body Request Dictionary.
 	 * @param parsed_url URL to send request to.
 	 * @param callback Callback to call on response received.
+	 * @param error_callback Callable to call if an error occur.
 	 * @param timeout Timeout of request.
 	 */
-	void asynchronous_request(const Dictionary &request_body, const Dictionary &parsed_url, const Callable &callback, float timeout = DEFAULT_REQUEST_TIMEOUT);
+	void asynchronous_request(const Dictionary &request_body, const Dictionary &parsed_url, const Callable &callback, const Callable &error_callback, float timeout = DEFAULT_REQUEST_TIMEOUT);
 };
 
 } //namespace godot

--- a/include/solana_client/solana_client.hpp
+++ b/include/solana_client/solana_client.hpp
@@ -62,8 +62,8 @@ private:
 	bool slot_range_enabled = false;
 
 	Callable ws_callback = callable_mp(this, &SolanaClient::ws_response_callback);
-	;
 	Callable rpc_callback = callable_mp(this, &SolanaClient::response_callback);
+	Callable error_callback = callable_mp(this, &SolanaClient::handle_rpc_error);
 
 	String ws_from_http(const String &http_url);
 	String get_real_url();
@@ -94,6 +94,7 @@ private:
 
 	void response_callback(const Dictionary &params);
 	void ws_response_callback(const Dictionary &params);
+	void handle_rpc_error(Error error_info);
 
 protected:
 	/**

--- a/include/solana_utils.hpp
+++ b/include/solana_utils.hpp
@@ -22,6 +22,8 @@ namespace godot {
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 
+#define VERBOSE_LOG_PREFIX "[SolanaSDK] "
+
 #define GDCLASS_CUSTOM(...)                                                                                                                                                                                                                                                             \
 	/* NOLINTBEGIN(hicpp-use-auto,modernize-use-auto,llvm-else-after-return,readability-else-after-return,cppcoreguidelines-pro-type-reinterpret-cast,cert-oop54-cpp,cppcoreguidelines-pro-type-const-cast,bugprone-unhandled-self-assignment,cppcoreguidelines-pro-type-cstyle-cast)*/ \
 	GDCLASS(__VA_ARGS__) /* NOLINTEND(hicpp-use-auto,modernize-use-auto,llvm-else-after-return,readability-else-after-return,cppcoreguidelines-pro-type-reinterpret-cast,cert-oop54-cpp,cppcoreguidelines-pro-type-const-cast,bugprone-unhandled-self-assignment,cppcoreguidelines-pro-type-cstyle-cast) */

--- a/include/transaction/transaction.hpp
+++ b/include/transaction/transaction.hpp
@@ -271,16 +271,18 @@ public:
 	/**
 	 * @brief Called when send is finalized.
 	 *
+	 * @param error Error code of the operation.
 	 * @param params Send response.
 	 */
-	void send_callback(Dictionary params);
+	void send_callback(Error error, Dictionary params);
 
 	/**
 	 * @brief Called when blockhash request is finalized.
 	 *
+	 * @param error Error code of the operation.
 	 * @param params Request response.
 	 */
-	void blockhash_callback(Dictionary params);
+	void blockhash_callback(Error error, Dictionary params);
 
 	/**
 	 * @setter{address_lookup_tables}

--- a/src/account.cpp
+++ b/src/account.cpp
@@ -12,6 +12,7 @@
 #include "godot_cpp/variant/callable_method_pointer.hpp"
 #include "godot_cpp/variant/dictionary.hpp"
 #include "godot_cpp/variant/packed_string_array.hpp"
+#include "godot_cpp/variant/utility_functions.hpp"
 #include "godot_cpp/variant/variant.hpp"
 
 #include "pubkey.hpp"
@@ -49,10 +50,6 @@ void Account::_bind_methods() {
 	ClassDB::add_property("Account", PropertyInfo(Variant::BOOL, "executable", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_executable", "get_executable");
 	ClassDB::add_property("Account", PropertyInfo(Variant::BOOL, "sync_with_chain", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_sync_with_chain", "get_sync_with_chain");
 	ClassDB::add_property("Account", PropertyInfo(Variant::OBJECT, "pre_simulate_transaction", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_pre_simulate_transaction", "get_pre_simulate_transaction");
-}
-
-Account::Account() :
-		seconds_since_fetch(max_fetch_interval) {
 }
 
 void Account::_process(double delta) {
@@ -341,6 +338,7 @@ void AccountFetcher::fetch_all() {
 	if (pending_fetch) {
 		return;
 	}
+	UtilityFunctions::print(fetch_accounts.keys());
 	get_multiple_accounts(fetch_accounts.keys());
 	pending_fetch = true;
 }

--- a/src/anchor/generic_anchor_resource.cpp
+++ b/src/anchor/generic_anchor_resource.cpp
@@ -104,6 +104,10 @@ GDExtensionObjectPtr GenericAnchorResource::_create_instance_func(void *data, GD
 	return new_object->_owner;
 }
 
+bool GenericAnchorResource::_is_extension_class() const {
+	return true;
+}
+
 const StringName *GenericAnchorResource::_get_extension_class_name() {
 	const StringName &string_name = get_class_static();
 	return &string_name;

--- a/src/candy_machine/candy_machine.cpp
+++ b/src/candy_machine/candy_machine.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 
+#include "godot_cpp/classes/global_constants.hpp"
 #include "godot_cpp/classes/object.hpp"
 #include "godot_cpp/core/class_db.hpp"
 #include "godot_cpp/core/error_macros.hpp"
@@ -11,6 +12,7 @@
 #include "godot_cpp/variant/callable.hpp"
 #include "godot_cpp/variant/dictionary.hpp"
 #include "godot_cpp/variant/packed_byte_array.hpp"
+#include "godot_cpp/variant/utility_functions.hpp"
 #include "godot_cpp/variant/variant.hpp"
 
 #include "account_meta.hpp"
@@ -222,12 +224,13 @@ Variant MplCandyMachine::new_candy_machine_authority_pda(const Variant &candy_ma
 
 void MplCandyMachine::get_candy_machine_info(const Variant &candy_machine_key) {
 	const Callable callback(this, "fetch_account_callback");
-	connect("http_response_received", callback, ConnectFlags::CONNECT_ONE_SHOT);
+	connect("http_request_completed", callback, ConnectFlags::CONNECT_ONE_SHOT);
 	get_account_info(Pubkey::string_from_variant(candy_machine_key));
 }
 
-void MplCandyMachine::fetch_account_callback(const Dictionary &params) {
-	if (!params.has("result")) {
+void MplCandyMachine::fetch_account_callback(const Error error, const Dictionary &params) {
+	if (error != Error::OK || !params.has("result")) {
+		UtilityFunctions::print_verbose(VERBOSE_LOG_PREFIX, vformat("Fetching account failed with error code (%d) and rpc result (%s)", error, params));
 		return;
 	}
 

--- a/src/solana_client/rpc_multi_http_request_client.cpp
+++ b/src/solana_client/rpc_multi_http_request_client.cpp
@@ -30,10 +30,10 @@ void RpcMultiHttpRequestClient::process(double delta) {
 	}
 }
 
-void RpcMultiHttpRequestClient::asynchronous_request(const Dictionary &request_body, const Dictionary &parsed_url, const Callable &callback, float timeout) {
+void RpcMultiHttpRequestClient::asynchronous_request(const Dictionary &request_body, const Dictionary &parsed_url, const Callable &callback, const Callable &error_callback, float timeout) {
 	RpcSingleHttpRequestClient *new_client = memnew_custom(RpcSingleHttpRequestClient);
 	requests.append(new_client);
-	new_client->asynchronous_request(request_body, parsed_url, callback, timeout);
+	new_client->asynchronous_request(request_body, parsed_url, callback, error_callback, timeout);
 }
 
 } //namespace godot

--- a/src/solana_utils.cpp
+++ b/src/solana_utils.cpp
@@ -298,15 +298,23 @@ PackedByteArray SolanaUtils::sha256_hash_array(const PackedStringArray &contents
 Variant SolanaUtils::get_nested_value(const Dictionary &dict, const String &path) {
 	const PackedStringArray keys = path.split("/", false);
 
-	ERR_FAIL_COND_V_CUSTOM(keys.is_empty(), nullptr);
+	if (keys.is_empty()) {
+		return nullptr;
+	}
 
 	Variant intermediate_dict = dict;
 	for (const auto &key : keys.slice(0, keys.size() - 1)) {
-		ERR_FAIL_COND_V_CUSTOM(!static_cast<Dictionary>(intermediate_dict).has(key), nullptr);
-		ERR_FAIL_COND_V_CUSTOM(static_cast<Dictionary>(intermediate_dict)[key].get_type() != Variant::DICTIONARY, nullptr);
+		if (!static_cast<Dictionary>(intermediate_dict).has(key)) {
+			return nullptr;
+		}
+		if (static_cast<Dictionary>(intermediate_dict)[key].get_type() != Variant::DICTIONARY) {
+			return nullptr;
+		}
 		intermediate_dict = static_cast<Variant>(static_cast<Dictionary>(intermediate_dict)[key]);
 	}
-	ERR_FAIL_COND_V_CUSTOM(!static_cast<Dictionary>(intermediate_dict).has(keys[keys.size() - 1]), nullptr);
+	if (!static_cast<Dictionary>(intermediate_dict).has(keys[keys.size() - 1])) {
+		return nullptr;
+	}
 
 	return static_cast<Dictionary>(intermediate_dict)[keys[keys.size() - 1]];
 }


### PR DESCRIPTION
There is no way to get error statuses from the requests being made. The http_response_received is also not accurate since it is also triggered when any error occurred. A new signal is added for request errors and one combined, to match the previous signal behavior on completion.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
