### PR TITLE
Add missing android bindings to signMessage function

### DIFF
--- a/android/plugin/src/main/java/plugin/walletadapterandroid/GDExtensionAndroidPlugin.kt
+++ b/android/plugin/src/main/java/plugin/walletadapterandroid/GDExtensionAndroidPlugin.kt
@@ -3,6 +3,7 @@ package plugin.walletadapterandroid
 import plugin.walletadapterandroid.myResult
 import plugin.walletadapterandroid.myAction
 import plugin.walletadapterandroid.myStoredTransaction
+import plugin.walletadapterandroid.myStoredTextMessage
 import plugin.walletadapterandroid.myMessageSignature
 import plugin.walletadapterandroid.myMessageSigningStatus
 import plugin.walletadapterandroid.myConnectedKey
@@ -94,10 +95,25 @@ class GDExtensionAndroidPlugin(godot: Godot): GodotPlugin(godot) {
             it.startActivity(intent)
         }
     }
+    
+    @UsedByGodot
+    fun signTextMessage(textMessage: String){
+        myAction = 2
+        myStoredTextMessage = textMessage
+        godot.getActivity()?.let {
+            val intent = Intent(it, ComposeWalletActivity::class.java)
+            it.startActivity(intent)
+        }
+    }
 
     @UsedByGodot
     fun getMessageSignature(): ByteArray {
         return myMessageSignature?: ByteArray(0)
+    }
+
+    @UsedByGodot
+    fun getLatestAction(): Int {
+        return myAction
     }
 
     @UsedByGodot

--- a/android/plugin/src/main/java/plugin/walletadapterandroid/MyComponentActivity.kt
+++ b/android/plugin/src/main/java/plugin/walletadapterandroid/MyComponentActivity.kt
@@ -34,5 +34,12 @@ class ComposeWalletActivity : ComponentActivity() {
                 signTransaction(sender)
             }
         }
+        else if (myAction == 2) {
+            hasConnectedWallet = true
+            val sender = ActivityResultSender(this)
+            setContent {
+                signTextMessage(sender)
+            }
+        }
     }
 }

--- a/example/WalletAdapterAndroid/flow.yaml
+++ b/example/WalletAdapterAndroid/flow.yaml
@@ -31,3 +31,10 @@ appId: com.example.app
 - tapOn:
     text: "AUTHORIZE"
     waitToSettleTimeoutMs: 50000
+- extendedWaitUntil: 
+     visible: "AUTHORIZE"
+     optional: true
+     timeout: 240000
+- tapOn:
+    text: "AUTHORIZE"
+    waitToSettleTimeoutMs: 50000

--- a/example/WalletAdapterAndroid/wallet_adapter_android.gd
+++ b/example/WalletAdapterAndroid/wallet_adapter_android.gd
@@ -90,9 +90,8 @@ func sign_text_message(test_id):
 func _ready():
 	await wallet_adapter_sign(0)
 	await wallet_adapter_sign(1)
-	
-	# TODO(VirAx): Enable once implemented.
-	#await sign_text_message(3)
+	await sign_text_message(3)
+
 	await wallet_adapter_in_deserialized_transaction()
 	
 	print("[ALL TESTS PASSED]")


### PR DESCRIPTION
Signing text messages is not possible due to missing bindings to the MWA library. The bindings are implemented to bridge fix the method.

* **Please check if the PR fulfills these requirements**
- [ ] The commit(s) are rebased and squashed
- [ ] Commits are concise and does not contain several different changes.
- [ ] Issue is linked.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
