### PR TITLE
add getAuthToken/setAuthToken for extensible auth cache layer

### DIFF
--- a/android/plugin/src/main/java/plugin/walletadapterandroid/GDExtensionAndroidPlugin.kt
+++ b/android/plugin/src/main/java/plugin/walletadapterandroid/GDExtensionAndroidPlugin.kt
@@ -186,4 +186,15 @@ class GDExtensionAndroidPlugin(godot: Godot): GodotPlugin(godot) {
         mySignAndSendStatus = 0
         mySignAndSendResult = ""
     }
+
+    @UsedByGodot
+    fun getAuthToken(): String {
+        return authToken ?: ""
+    }
+
+    @UsedByGodot
+    fun setAuthToken(token: String) {
+        authToken = if (token.isEmpty()) null else token
+        Log.i("godot", "[KotlinPlugin] setAuthToken | token_len=${authToken?.length ?: 0}")
+    }
 }


### PR DESCRIPTION
### 📝 Pull Request Summary                                                                                                                                                                               
                                                                                                                                                                                                            
The MWA `authToken` lives in a Kotlin global variable and is lost when the app process dies. There is no way to read or write this token from GDScript, so apps cannot persist authorization across restarts. Users have to re-authorize through the wallet picker every time the app is killed and relaunched.                                                                                               
                                                                                                                                                                                                            
This PR exposes `getAuthToken()` and `setAuthToken(token)` on the Kotlin plugin so GDScript can cache the token to disk and restore it on next launch. The app decides the storage backend (file,         
encrypted, cloud, etc.).
                                                                                                                                                                                                            
  **Before this fix:**                                                                                                                                                                                    
  - `authToken` only exists in Kotlin memory, no way to access from GDScript
  - Kill app, relaunch: user must re-authorize through wallet picker every time                                                                                                                             
  - No extensible cache layer for MWA authorization tokens                                                                                                                                                  
                                                                                                                                                                                                            
  **After this fix:**                                                                                                                                                                                       
  - `getAuthToken()` returns the current Kotlin-side auth token (or empty string)                                                                                                                           
  - `setAuthToken(token)` sets or clears the token from GDScript                                                                                                                                            
  - Apps can save the token to disk after authorize, restore it on next launch with `setAuthToken`, and skip the wallet picker entirely                                                                     
  - Disconnect calls `setAuthToken("")` + `clearStateFullReset()` to force fresh picker on next connect                                                                                                     
                                                                                                                                                                                                            
  ### 🔧 Changes Made                                                                                                                                                                                       
                                                                                                                                                                                                            
 **GDExtensionAndroidPlugin.kt:**                                                                                                                                                                          
  - Added `@UsedByGodot fun getAuthToken(): String` to read the current auth token from GDScript
  - Added `@UsedByGodot fun setAuthToken(token: String)` to set or clear the token from GDScript                                                                                                            
  - Deterministic logging on `setAuthToken` showing `token_len`                                                                                                                                             
                                                                                                                                                                                                            
 ### 📌 Other Information                                                                                                                                                                                  
  - Tested on Solana Seeker with Phantom wallet                                                                                                                                                             
  - Fresh connect: auth token synced from Kotlin (`token_len=118`), saved to disk via GDScript `AuthCache`                                                                                                  
  - Kill app + relaunch: token restored from disk cache, pushed to Kotlin via `setAuthToken`, reconnect without wallet picker                                                                               
  - Disconnect: token cleared via `setAuthToken("")` + `clearStateFullReset()`, next connect opens fresh picker                                                                                             
  - Working example app with full cache implementation: https://github.com/mstevens843/godot-solana-mwa-example        